### PR TITLE
修复Skript表达式错误的抛出异常

### DIFF
--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprCustomItem.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprCustomItem.java
@@ -7,13 +7,12 @@ import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import net.momirealms.craftengine.bukkit.api.CraftEngineItems;
+import net.momirealms.craftengine.core.item.CustomItem;
 import net.momirealms.craftengine.core.item.ItemBuildContext;
 import net.momirealms.craftengine.core.util.Key;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
 
 public class ExprCustomItem extends SimpleExpression<ItemStack> {
 
@@ -36,7 +35,8 @@ public class ExprCustomItem extends SimpleExpression<ItemStack> {
         String itemId = this.itemId.getSingle(e);
         if (itemId == null)
             return null;
-        return new ItemStack[] {Objects.requireNonNull(CraftEngineItems.byId(Key.of(itemId))).buildItemStack(ItemBuildContext.EMPTY)};
+        CustomItem<ItemStack> customItem = CraftEngineItems.byId(Key.of(itemId));
+        return customItem == null ? null : new ItemStack[] {customItem.buildItemStack(ItemBuildContext.EMPTY)};
     }
 
     @Override

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprEntityFurnitureID.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprEntityFurnitureID.java
@@ -5,7 +5,7 @@ import net.momirealms.craftengine.bukkit.api.CraftEngineFurniture;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
+import java.util.Optional;
 
 public class ExprEntityFurnitureID extends SimplePropertyExpression<Object, String> {
 
@@ -15,8 +15,11 @@ public class ExprEntityFurnitureID extends SimplePropertyExpression<Object, Stri
 
     @Override
     public @Nullable String convert(Object object) {
-        if (object instanceof Entity entity && CraftEngineFurniture.isFurniture(entity))
-            return Objects.requireNonNull(CraftEngineFurniture.getLoadedFurnitureByBaseEntity(entity)).id().toString();
+        if (object instanceof Entity entity && CraftEngineFurniture.isFurniture(entity)) {
+            return Optional.ofNullable(CraftEngineFurniture.getLoadedFurnitureByBaseEntity(entity))
+                    .map(it -> it.id().toString())
+                    .orElse(null);
+        }
         return null;
     }
 


### PR DESCRIPTION
Skript表达式中如果没找到对应ID物品则返回null, 而不是抛出npe.