### PR TITLE
支持在配置文件使用::分割层级, 同时自动合并配置.

### DIFF
--- a/common-files/src/main/resources/translations/zh_cn.yml
+++ b/common-files/src/main/resources/translations/zh_cn.yml
@@ -65,6 +65,7 @@ command.send_resource_pack.success.single: "<white>发送资源包给 <arg:0></w
 command.send_resource_pack.success.multiple: "<white>发送资源包给 <arg:0> 个玩家</white>"
 warning.config.pack.duplicated_files: "</red>发现重复文件 请通过 config.yml 的 'resource-pack.duplicated-files-handler' 部分解决</red>"
 warning.config.yaml.duplicated_key: "<red>在文件 <arg:0> 发现问题 - 在第<arg:2>行发现重复的键 '<arg:1>', 这可能会导致一些意料之外的问题.</red>"
+warning.config.yaml.key_path_conflict: "<red>在文件 <arg:0> 发现问题 - 在第<arg:2>行发现重复且值类型不同的键 '<arg:1>', 这可能会导致一些意料之外的问题.</red>"
 warning.config.type.int: "<yellow>在文件 <arg:0> 发现问题 - 无法加载 '<arg:1>': 无法将 '<arg:2>' 转换为整数类型 (选项 '<arg:3>')</yellow>"
 warning.config.type.float: "<yellow>在文件 <arg:0> 发现问题 - 无法加载 '<arg:1>': 无法将 '<arg:2>' 转换为浮点数类型 (选项 '<arg:3>')</yellow>"
 warning.config.type.boolean: "<yellow>在文件 <arg:0> 发现问题 - 无法加载 '<arg:1>': 无法将 '<arg:2>' 转换为布尔类型 (选项 '<arg:3>')</yellow>"

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/config/StringKeyConstructor.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/config/StringKeyConstructor.java
@@ -50,16 +50,14 @@ public class StringKeyConstructor extends SafeConstructor {
      */
     @Override
     public Object constructObject(Node node) {
-        if (node instanceof MappingNode mappingNode) {
-            if (isValueSelectorNode(mappingNode)) {
-                // 场景B: 这是一个值选择器，解析它以获得单个值
-                return constructVersionedValue(mappingNode);
-            }
+        if (node instanceof MappingNode mappingNode && isValueSelectorNode(mappingNode)) {
+            return constructVersionedValue(mappingNode);
         }
         // 对于所有其他情况 (包括需要合并的Map)，使用默认的构造逻辑
         // super.constructObject 会最终调用我们重写的 constructMapping
         return super.constructObject(node);
     }
+
 
     /**
      * 场景A (块合并与路径展开): 构造一个Map，同时处理其中的版本化块合并和 `::` 分隔的深层键。
@@ -68,117 +66,118 @@ public class StringKeyConstructor extends SafeConstructor {
     @Override
     protected Map<Object, Object> constructMapping(MappingNode node) {
         Map<Object, Object> map = new LinkedHashMap<>();
+
         for (NodeTuple tuple : node.getValue()) {
             Node keyNode = tuple.getKeyNode();
             if (!(keyNode instanceof ScalarNode)) continue;
-
-            String key = constructScalar((ScalarNode) keyNode);
             Node valueNode = tuple.getValueNode();
 
-            // 处理 版本化块 合并.
-            if (key.startsWith(VERSION_PREFIX)) {
-                String versionSpec = key.substring(VERSION_PREFIX.length());
-                if (isVersionMatch(versionSpec)) {
-                    if (valueNode instanceof MappingNode) {
-                        // 将版本匹配的map内容合并到当前map
-                        Map<Object, Object> versionedMap = constructMapping((MappingNode) valueNode);
-                        mergeMap(map, versionedMap);
-                    } else {
-                        logWarning("versioned_key_not_a_map", key, valueNode);
-                    }
-                }
-            }
-            // 处理::分隔的键 ->  {a::b::c: value} 和 {a::b: {c: value}}.
-            else if (key.contains(DEEP_KEY_SEPARATOR)) {
-                processDeepKey(map, key, valueNode, keyNode);
-            }
-            // 处理正常的内容.
-            else {
-                Object value = constructObject(valueNode);
+            String key = constructScalar((ScalarNode) keyNode);
 
-                // 检查是否需要与现有的Map合并
-                Object existing = map.get(key);
-                if (existing instanceof Map && value instanceof Map) {
-                    // 如果已存在同名的Map（可能是由深层键创建的），则合并它们
-                    mergeMap((Map<Object, Object>) existing, (Map<Object, Object>) value);
-                } else {
-                    // 否则正常设置
-                    Object previous = map.put(key, value);
-
-                    // 如果之前有值,
-                    if (previous != null && !(previous instanceof Map)) {
-                        logWarning("duplicated_key", key, keyNode);
-                    }
-                }
-            }
+            // 处理 版本化块.
+            if (key.startsWith(VERSION_PREFIX)) processVersionedBlock(map, key, valueNode);
+            // 处理 深层键 -> {a::b::c: value} 和 {a::b: {c: value}}.
+            else if (key.contains(DEEP_KEY_SEPARATOR)) processDeepKey(map, key, valueNode, keyNode);
+            // 处理 正常键.
+            else processRegularKey(map, key, valueNode, keyNode);
         }
+
         return map;
     }
 
-    /**
-     * 处理深层键的逻辑，支持完全深层键和部分深层键的合并
-     */
-    @SuppressWarnings("unchecked")
-    private void processDeepKey(Map<Object, Object> rootMap, String key, Node valueNode, Node keyNode) {
-        String[] parts = key.split(DEEP_KEY_SEPARATOR);
+
+    // 处理版本化块合并
+    private void processVersionedBlock(Map<Object, Object> targetMap, String key, Node valueNode) {
+        String versionSpec = key.substring(VERSION_PREFIX.length());
+
+        if (isVersionMatch(versionSpec)) {
+            if (valueNode instanceof MappingNode mappingNode) {
+                Map<Object, Object> versionedMap = constructMapping(mappingNode);
+                mergeMap(targetMap, versionedMap, "", valueNode);
+            } else {
+                logWarning("versioned_key_not_a_map", key, valueNode);
+            }
+        }
+    }
+
+    // 处理深层键
+    private void processDeepKey(Map<Object, Object> rootMap, String fullKey, Node valueNode, Node keyNode) {
+        String[] keyParts = fullKey.split(DEEP_KEY_SEPARATOR);
         Map<Object, Object> currentMap = rootMap;
 
-        // 遍历除最后一个部分外的所有路径，创建或导航到嵌套的map
-        for (int i = 0; i < parts.length - 1; i++) {
-            String part = parts[i];
-            Object nextObject = currentMap.get(part);
-            if (nextObject instanceof Map) {
-                currentMap = (Map<Object, Object>) nextObject;
+        // 创建必要的的中间层级
+        for (int i = 0; i < keyParts.length - 1; i++) {
+            String keyPart = keyParts[i];
+            Object existingValue = currentMap.get(keyPart);
+
+            if (existingValue instanceof Map) {
+                currentMap = (Map<Object, Object>) existingValue;
             } else {
-                // 如果路径中存在一个非map的值，发出警告并覆盖它
-                if (nextObject != null) {
-                    logWarning("key_path_conflict", part, keyNode);
+                if (existingValue != null) {
+                    logWarning("key_path_conflict", keyPart, keyNode);
                 }
                 Map<Object, Object> newMap = new LinkedHashMap<>();
-                currentMap.put(part, newMap);
+                currentMap.put(keyPart, newMap);
                 currentMap = newMap;
             }
         }
 
-        // 处理最后一个部分
-        String finalKey = parts[parts.length - 1];
-        Object value = constructObject(valueNode);
+        // 处理最终键
+        String finalKey = keyParts[keyParts.length - 1];
+        Object newValue = constructObject(valueNode);
+        String keyPath = String.join(DEEP_KEY_SEPARATOR, keyParts); // 构建完整的键路径字符串
 
-        // 检查最终键是否需要合并
-        Object existing = currentMap.get(finalKey);
-        if (existing instanceof Map && value instanceof Map) {
-            // 如果目标位置已经有一个Map，且新值也是Map，则合并它们
-            mergeMap((Map<Object, Object>) existing, (Map<Object, Object>) value);
+        setValueWithDuplicationCheck(currentMap, finalKey, newValue, keyPath, keyNode);
+    }
+
+    // 处理普通键
+    private void processRegularKey(Map<Object, Object> targetMap, String key, Node valueNode, Node keyNode) {
+        Object newValue = constructObject(valueNode);
+        setValueWithDuplicationCheck(targetMap, key, newValue, key, keyNode);
+    }
+
+
+    // 设置值并检查重复键
+    @SuppressWarnings("unchecked")
+    private void setValueWithDuplicationCheck(Map<Object, Object> targetMap, String key, Object newValue, String fullKeyPath, Node keyNode) {
+        Object existingValue = targetMap.get(key);
+
+        if (existingValue == null) {
+            // 键不存在，直接设置.
+            targetMap.put(key, newValue);
+        } else if (existingValue instanceof Map && newValue instanceof Map) {
+            // 两个都是Map，直接合并.
+            mergeMap((Map<Object, Object>) existingValue, (Map<Object, Object>) newValue, fullKeyPath, keyNode);
         } else {
-            // 否则直接设置值
-            Object previous = currentMap.put(finalKey, value);
-            if (previous != null && !(previous instanceof Map)) {
-                // 只有当之前的值不是Map时才报告重复键警告
-                logWarning("duplicated_key", key, keyNode);
-            }
+            // 存在重复键（至少一个不是Map）
+            logWarning("duplicated_key", fullKeyPath, keyNode);
+            targetMap.put(key, newValue);
         }
     }
 
-    /**
-     * 合并两个Map
-     */
+
+    // 合并两个Map并检查重复键
     @SuppressWarnings("unchecked")
-    private void mergeMap(Map<Object, Object> target, Map<Object, Object> source) {
+    private void mergeMap(Map<Object, Object> target, Map<Object, Object> source, String parentPath, Node sourceNode) {
         for (Map.Entry<Object, Object> entry : source.entrySet()) {
-            Object key = entry.getKey();
+            String key = entry.getKey().toString();
             Object sourceValue = entry.getValue();
             Object targetValue = target.get(key);
+            String currentPath = parentPath.isEmpty() ? key : parentPath + DEEP_KEY_SEPARATOR + key;
 
-            // 如果都是Map，则递归合并.
-            if (targetValue instanceof Map && sourceValue instanceof Map) {
-                mergeMap((Map<Object, Object>) targetValue, (Map<Object, Object>) sourceValue);
-                return;
+            // Map不存在该键，直接添加喵.
+            if (targetValue == null) target.put(key, sourceValue);
+            // 两个值都是Map，还需继续合并.
+            else if (targetValue instanceof Map && sourceValue instanceof Map)
+                mergeMap((Map<Object, Object>) targetValue, (Map<Object, Object>) sourceValue, currentPath, sourceNode);
+            // 发现重复的键, 爆炸了喵.
+            else {
+                logWarning("duplicated_key", currentPath, sourceNode);
+                target.put(key, sourceValue);
             }
-
-            // TODO 不能覆盖, 得想办法丢个异常.
-            target.put(key, sourceValue);
         }
     }
+
 
     /**
      * 检查一个MappingNode是否是“值选择器”（即所有键都以 '$$' 开头）。


### PR DESCRIPTION
测试案例和结果;

```
items#topaz_gears:
  default:topaz_axe:
    material: golden_axe

    # 测试案例 
    data::item-name: <!i><#FF8C00><i18n:item.topaz_axe>
    data::tooltip-style: minecraft:topaz
      
    data::components::minecraft:max_damage: 12

    data::components::minecraft:food::nutrition: 6
    data::components::minecraft:food:
      saturation: 6
      can_always_eat: true
    
    data::components:
      minecraft:food:
        can_always_eat: false # 应该爆炸

    data:
      components:
        minecraft:max_stack_size: 16    
    data::components::minecraft:max_stack_size: 18 # 应该爆炸


    somekey:
      scalar: "wow!"
    somekey::scalar::warn: "这会强行覆盖掉上面的key." # 应该爆炸, 触发新增的新警告


# [23:16:32 INFO]: [CraftEngine] Loaded pack: remove_shulker_head. Default namespace: minecraft
# [23:16:32 INFO]: 在文件 CraftEngine\resources\default\configuration\test.yml 发现问题 - 在第33行发现重复的键 'data::components::minecraft:food::can_always_eat', 这可能会导致一些意料之外的问题.
# [23:16:32 INFO]: 在文件 CraftEngine\resources\default\configuration\test.yml 发现问题 - 在第40行发现重复的键 'data::components::minecraft:max_stack_size', 这可能会导致一些意料之外的问题.
# [23:16:32 INFO]: 在文件 CraftEngine\resources\default\configuration\test.yml 发现问题 - 在第45行发现重复且值类型不同的键 'scalar', 这可能会导致一些意料之外的问题.
# [23:16:32 INFO]: [CraftEngine] Loaded packs. Took 57.52 ms

```