### PR TITLE
Improve entity and block interaction handling

### DIFF
--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/item/listener/ItemEventListener.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/item/listener/ItemEventListener.java
@@ -36,6 +36,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Openable;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -66,6 +67,8 @@ public class ItemEventListener implements Listener {
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onInteractEntity(PlayerInteractEntityEvent event) {
+        Player player = event.getPlayer();
+        Entity entity = event.getRightClicked();
         BukkitServerPlayer serverPlayer = this.plugin.adapt(event.getPlayer());
         if (serverPlayer == null) return;
         InteractionHand hand = event.getHand() == EquipmentSlot.HAND ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND;
@@ -75,15 +78,17 @@ public class ItemEventListener implements Listener {
         Optional<CustomItem<ItemStack>> optionalCustomItem = itemInHand.getCustomItem();
         if (optionalCustomItem.isEmpty()) return;
 
-        Cancellable cancellable = Cancellable.of(event::isCancelled, event::setCancelled);
-        PlayerOptionalContext context = PlayerOptionalContext.of(serverPlayer, ContextHolder.builder()
-                .withOptionalParameter(DirectContextParameters.ITEM_IN_HAND, itemInHand)
-                .withParameter(DirectContextParameters.EVENT, cancellable)
-                .withParameter(DirectContextParameters.POSITION, LocationUtils.toWorldPosition(event.getRightClicked().getLocation()))
-                .withParameter(DirectContextParameters.HAND, hand)
-        );
-        CustomItem<ItemStack> customItem = optionalCustomItem.get();
-        customItem.execute(context, EventTrigger.RIGHT_CLICK);
+        if (!InteractUtils.isEntityInteractable(player, entity, itemInHand)) {
+            Cancellable cancellable = Cancellable.of(event::isCancelled, event::setCancelled);
+            PlayerOptionalContext context = PlayerOptionalContext.of(serverPlayer, ContextHolder.builder()
+                    .withOptionalParameter(DirectContextParameters.ITEM_IN_HAND, itemInHand)
+                    .withParameter(DirectContextParameters.EVENT, cancellable)
+                    .withParameter(DirectContextParameters.POSITION, LocationUtils.toWorldPosition(event.getRightClicked().getLocation()))
+                    .withParameter(DirectContextParameters.HAND, hand)
+            );
+            CustomItem<ItemStack> customItem = optionalCustomItem.get();
+            customItem.execute(context, EventTrigger.RIGHT_CLICK);
+        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
@@ -275,10 +280,12 @@ public class ItemEventListener implements Listener {
                         .withParameter(DirectContextParameters.EVENT, dummy)
                 );
                 CustomItem<ItemStack> customItem = optionalCustomItem.get();
-                customItem.execute(context, EventTrigger.RIGHT_CLICK);
-                if (dummy.isCancelled()) {
-                    event.setCancelled(true);
-                    return;
+                if (!InteractUtils.isInteractable(player, blockData, hitResult, null)) {
+                    customItem.execute(context, EventTrigger.RIGHT_CLICK);
+                    if (dummy.isCancelled()) {
+                        event.setCancelled(true);
+                        return;
+                    }
                 }
             }
 

--- a/core/src/main/java/net/momirealms/craftengine/core/block/BlockKeys.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/block/BlockKeys.java
@@ -42,6 +42,9 @@ public final class BlockKeys {
     public static final Key CHAIN_COMMAND_BLOCK = Key.of("minecraft:chain_command_block");
     public static final Key REPEATING_COMMAND_BLOCK = Key.of("minecraft:repeating_command_block");
     public static final Key DECORATED_POT = Key.of("minecraft:decorated_pot");
+    public static final Key CHISELED_BOOKSHELF = Key.of("minecraft:chiseled_bookshelf");
+    public static final Key REDSTONE_ORE = Key.of("minecraft:redstone_ore");
+    public static final Key DEEPSLATE_REDSTONE_ORE = Key.of("minecraft:deepslate_redstone_ore");
 
     public static final Key CAKE = Key.of("minecraft:cake");
     public static final Key CANDLE_CAKE = Key.of("minecraft:candle_cake");


### PR DESCRIPTION
Added checks for interactable entities and blocks, including chiseled bookshelf, redstone ore, and deepslate redstone ore. Updated ItemEventListener to use new InteractUtils methods for entity and block interactions, preventing custom item execution on interactable entities and blocks.