### PR TITLE
Put tag resolvers in contexts in mutable lists

### DIFF
--- a/core/src/main/java/net/momirealms/craftengine/core/font/AbstractFontManager.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/font/AbstractFontManager.java
@@ -122,7 +122,7 @@ public abstract class AbstractFontManager implements FontManager {
                     PlayerOptionalContext.of(player, ContextHolder.builder()
                             .withOptionalParameter(EmojiParameters.EMOJI, emoji.emojiImage())
                             .withParameter(EmojiParameters.KEYWORD, emoji.keywords().get(0))
-                    ).tagResolvers()
+                    ).combinedTagResolver()
             );
             replacements.put(fragment, AdventureHelper.componentToMiniMessage(content));
         }
@@ -168,7 +168,7 @@ public abstract class AbstractFontManager implements FontManager {
                     PlayerOptionalContext.of(player, ContextHolder.builder()
                             .withOptionalParameter(EmojiParameters.EMOJI, emoji.emojiImage())
                             .withParameter(EmojiParameters.KEYWORD, emoji.keywords().get(0))
-                    ).tagResolvers())
+                    ).combinedTagResolver())
             );
             if (emojis.size() >= maxTimes) break;
         }
@@ -200,7 +200,7 @@ public abstract class AbstractFontManager implements FontManager {
                     PlayerOptionalContext.of(player, ContextHolder.builder()
                             .withOptionalParameter(EmojiParameters.EMOJI, emoji.emojiImage())
                             .withParameter(EmojiParameters.KEYWORD, emoji.keywords().get(0))
-                    ).tagResolvers()
+                    ).combinedTagResolver()
             ));
             if (emojis.size() >= maxTimes) break;
         }

--- a/core/src/main/java/net/momirealms/craftengine/core/item/modifier/AttributeModifiersModifier.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/item/modifier/AttributeModifiersModifier.java
@@ -125,7 +125,7 @@ public class AttributeModifiersModifier<I> implements ItemDataModifier<I> {
                     AttributeModifier.Display.Type displayType = display.type();
                     displayTag.putString("type", displayType.name().toLowerCase(Locale.ENGLISH));
                     if (displayType == AttributeModifier.Display.Type.OVERRIDE) {
-                        displayTag.put("value", AdventureHelper.componentToTag(AdventureHelper.miniMessage().deserialize(display.value(), context.tagResolvers())));
+                        displayTag.put("value", AdventureHelper.componentToTag(AdventureHelper.miniMessage().deserialize(display.value(), context.combinedTagResolver())));
                     }
                     modifierTag.put("display", displayTag);
                 }

--- a/core/src/main/java/net/momirealms/craftengine/core/item/modifier/CustomNameModifier.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/item/modifier/CustomNameModifier.java
@@ -32,7 +32,7 @@ public class CustomNameModifier<I> implements ItemDataModifier<I> {
 
     @Override
     public Item<I> apply(Item<I> item, ItemBuildContext context) {
-        item.customNameComponent(AdventureHelper.miniMessage().deserialize(this.argument, context.tagResolvers()));
+        item.customNameComponent(AdventureHelper.miniMessage().deserialize(this.argument, context.combinedTagResolver()));
         return item;
     }
 

--- a/core/src/main/java/net/momirealms/craftengine/core/item/modifier/ItemNameModifier.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/item/modifier/ItemNameModifier.java
@@ -23,7 +23,7 @@ public class ItemNameModifier<I> implements ItemDataModifier<I> {
 
     @Override
     public Item<I> apply(Item<I> item, ItemBuildContext context) {
-        item.itemNameComponent(AdventureHelper.miniMessage().deserialize(this.argument, context.tagResolvers()));
+        item.itemNameComponent(AdventureHelper.miniMessage().deserialize(this.argument, context.combinedTagResolver()));
         return item;
     }
 

--- a/core/src/main/java/net/momirealms/craftengine/core/item/modifier/lore/LoreModification.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/item/modifier/lore/LoreModification.java
@@ -18,7 +18,7 @@ public record LoreModification(Operation operation, boolean split, String[] cont
     }
 
     public Stream<Component> parseAsStream(ItemBuildContext context) {
-        Stream<Component> parsed = Arrays.stream(this.content).map(string -> AdventureHelper.miniMessage().deserialize(string, context.tagResolvers()));
+        Stream<Component> parsed = Arrays.stream(this.content).map(string -> AdventureHelper.miniMessage().deserialize(string, context.combinedTagResolver()));
         return this.split ? parsed.map(AdventureHelper::splitLines).flatMap(List::stream) : parsed;
     }
 

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/AbstractCommonContext.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/AbstractCommonContext.java
@@ -4,13 +4,15 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.momirealms.craftengine.core.plugin.text.minimessage.*;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public abstract class AbstractCommonContext implements Context {
     protected final ContextHolder contexts;
     protected final List<AdditionalParameterProvider> additionalParameterProviders;
-    protected TagResolver[] tagResolvers;
+    protected final List<TagResolver> tagResolvers = new ArrayList<>(List.of(ShiftTag.INSTANCE, ImageTag.INSTANCE, new I18NTag(this), new NamedArgumentTag(this),
+        new PlaceholderTag(this), new ExpressionTag(this), new GlobalVariableTag(this)));
 
     public AbstractCommonContext(ContextHolder contexts) {
         this.contexts = contexts;
@@ -30,11 +32,7 @@ public abstract class AbstractCommonContext implements Context {
 
     @Override
     @NotNull
-    public TagResolver[] tagResolvers() {
-        if (this.tagResolvers == null) {
-            this.tagResolvers = new TagResolver[]{ShiftTag.INSTANCE, ImageTag.INSTANCE, new I18NTag(this), new NamedArgumentTag(this),
-                    new PlaceholderTag(this), new ExpressionTag(this), new GlobalVariableTag(this)};
-        }
+    public List<TagResolver> tagResolvers() {
         return this.tagResolvers;
     }
 

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/Context.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/Context.java
@@ -1,5 +1,6 @@
 package net.momirealms.craftengine.core.plugin.context;
 
+import java.util.List;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 import java.util.Optional;
@@ -8,7 +9,11 @@ public interface Context {
 
     ContextHolder contexts();
 
-    TagResolver[] tagResolvers();
+    List<TagResolver> tagResolvers();
+
+    default TagResolver combinedTagResolver() {
+        return TagResolver.resolver(tagResolvers());
+    }
 
     <T> Optional<T> getOptionalParameter(ContextKey<T> parameter);
 

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/PlayerOptionalContext.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/PlayerOptionalContext.java
@@ -1,9 +1,7 @@
 package net.momirealms.craftengine.core.plugin.context;
 
-import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.momirealms.craftengine.core.entity.player.Player;
 import net.momirealms.craftengine.core.plugin.context.parameter.DirectContextParameters;
-import net.momirealms.craftengine.core.plugin.text.minimessage.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,15 +49,5 @@ public class PlayerOptionalContext extends AbstractChainParameterContext impleme
 
     public boolean isPlayerPresent() {
         return this.player != null;
-    }
-
-    @Override
-    @NotNull
-    public TagResolver[] tagResolvers() {
-        if (this.tagResolvers == null) {
-            this.tagResolvers = new TagResolver[]{ShiftTag.INSTANCE, ImageTag.INSTANCE, new PlaceholderTag(this), new I18NTag(this),
-                    new NamedArgumentTag(this), new ExpressionTag(this), new GlobalVariableTag(this)};
-        }
-        return this.tagResolvers;
     }
 }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/ViewerContext.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/ViewerContext.java
@@ -1,5 +1,7 @@
 package net.momirealms.craftengine.core.plugin.context;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.momirealms.craftengine.core.plugin.text.minimessage.*;
 
@@ -8,11 +10,23 @@ import java.util.Optional;
 public class ViewerContext implements RelationalContext {
     private final Context owner;
     private final PlayerOptionalContext viewer;
-    private TagResolver[] tagResolvers;
+    private final List<TagResolver> tagResolvers = new ArrayList<>();
 
     public ViewerContext(Context owner, PlayerOptionalContext viewer) {
         this.owner = owner;
         this.viewer = viewer;
+            if (this.owner instanceof PlayerOptionalContext context && context.player != null && this.viewer.player != null) {
+                this.tagResolvers.addAll(List.of(new RelationalPlaceholderTag(context.player, this.viewer.player, this),
+                        ShiftTag.INSTANCE, ImageTag.INSTANCE,
+                        new PlaceholderTag(this.owner), new ViewerPlaceholderTag(this.viewer),
+                        new NamedArgumentTag(this.owner), new ViewerNamedArgumentTag(this.viewer),
+                        new I18NTag(this), new ExpressionTag(this), new GlobalVariableTag(this)));
+            } else {
+                this.tagResolvers.addAll(List.of(ShiftTag.INSTANCE, ImageTag.INSTANCE,
+                        new PlaceholderTag(this.owner), new ViewerPlaceholderTag(this.viewer),
+                        new NamedArgumentTag(this.owner), new ViewerNamedArgumentTag(this.viewer),
+                        new I18NTag(this), new ExpressionTag(this), new GlobalVariableTag(this)));
+            }
     }
 
     public static ViewerContext of(Context owner, PlayerOptionalContext viewer) {
@@ -50,21 +64,7 @@ public class ViewerContext implements RelationalContext {
     }
 
     @Override
-    public TagResolver[] tagResolvers() {
-        if (this.tagResolvers == null) {
-            if (this.owner instanceof PlayerOptionalContext context && context.player != null && this.viewer.player != null) {
-                this.tagResolvers = new TagResolver[]{new RelationalPlaceholderTag(context.player, this.viewer.player, this),
-                        ShiftTag.INSTANCE, ImageTag.INSTANCE,
-                        new PlaceholderTag(this.owner), new ViewerPlaceholderTag(this.viewer),
-                        new NamedArgumentTag(this.owner), new ViewerNamedArgumentTag(this.viewer),
-                        new I18NTag(this), new ExpressionTag(this), new GlobalVariableTag(this)};
-            } else {
-                this.tagResolvers = new TagResolver[]{ShiftTag.INSTANCE, ImageTag.INSTANCE,
-                        new PlaceholderTag(this.owner), new ViewerPlaceholderTag(this.viewer),
-                        new NamedArgumentTag(this.owner), new ViewerNamedArgumentTag(this.viewer),
-                        new I18NTag(this), new ExpressionTag(this), new GlobalVariableTag(this)};
-            }
-        }
+    public List<TagResolver> tagResolvers() {
         return this.tagResolvers;
     }
 }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/ActionBarFunction.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/ActionBarFunction.java
@@ -29,12 +29,12 @@ public class ActionBarFunction<CTX extends Context> extends AbstractConditionalF
     public void runInternal(CTX ctx) {
         if (this.selector == null) {
             ctx.getOptionalParameter(DirectContextParameters.PLAYER).ifPresent(it -> {
-                it.sendActionBar(AdventureHelper.miniMessage().deserialize(this.message.get(ctx), ctx.tagResolvers()));
+                it.sendActionBar(AdventureHelper.miniMessage().deserialize(this.message.get(ctx), ctx.combinedTagResolver()));
             });
         } else {
             for (Player viewer : this.selector.get(ctx)) {
                 RelationalContext relationalContext = ViewerContext.of(ctx, PlayerOptionalContext.of(viewer, ContextHolder.EMPTY));
-                viewer.sendActionBar(AdventureHelper.miniMessage().deserialize(this.message.get(relationalContext), relationalContext.tagResolvers()));
+                viewer.sendActionBar(AdventureHelper.miniMessage().deserialize(this.message.get(relationalContext), relationalContext.combinedTagResolver()));
             }
         }
     }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/MessageFunction.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/MessageFunction.java
@@ -33,14 +33,14 @@ public class MessageFunction<CTX extends Context> extends AbstractConditionalFun
         if (this.selector == null) {
             ctx.getOptionalParameter(DirectContextParameters.PLAYER).ifPresent(it -> {
                 for (TextProvider c : this.messages) {
-                    it.sendMessage(AdventureHelper.miniMessage().deserialize(c.get(ctx), ctx.tagResolvers()), this.overlay);
+                    it.sendMessage(AdventureHelper.miniMessage().deserialize(c.get(ctx), ctx.combinedTagResolver()), this.overlay);
                 }
             });
         } else {
             for (Player viewer : this.selector.get(ctx)) {
                 RelationalContext relationalContext = ViewerContext.of(ctx, PlayerOptionalContext.of(viewer, ContextHolder.EMPTY));
                 for (TextProvider c : this.messages) {
-                    viewer.sendMessage(AdventureHelper.miniMessage().deserialize(c.get(relationalContext), relationalContext.tagResolvers()), this.overlay);
+                    viewer.sendMessage(AdventureHelper.miniMessage().deserialize(c.get(relationalContext), relationalContext.combinedTagResolver()), this.overlay);
                 }
             }
         }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/OpenWindowFunction.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/OpenWindowFunction.java
@@ -39,7 +39,7 @@ public class OpenWindowFunction<CTX extends Context> extends AbstractConditional
             ctx.getOptionalParameter(DirectContextParameters.PLAYER).ifPresent(it -> {
                 CraftEngine.instance().guiManager().openInventory(it, this.guiType);
                 if (this.optionalTitle != null) {
-                    CraftEngine.instance().guiManager().updateInventoryTitle(it, AdventureHelper.miniMessage().deserialize(this.optionalTitle.get(ctx), ctx.tagResolvers()));
+                    CraftEngine.instance().guiManager().updateInventoryTitle(it, AdventureHelper.miniMessage().deserialize(this.optionalTitle.get(ctx), ctx.combinedTagResolver()));
                 }
             });
         } else {
@@ -47,7 +47,7 @@ public class OpenWindowFunction<CTX extends Context> extends AbstractConditional
                 CraftEngine.instance().guiManager().openInventory(viewer, this.guiType);
                 if (this.optionalTitle != null) {
                     RelationalContext relationalContext = ViewerContext.of(ctx, PlayerOptionalContext.of(viewer, ContextHolder.EMPTY));
-                    CraftEngine.instance().guiManager().updateInventoryTitle(viewer, AdventureHelper.miniMessage().deserialize(this.optionalTitle.get(relationalContext), relationalContext.tagResolvers()));
+                    CraftEngine.instance().guiManager().updateInventoryTitle(viewer, AdventureHelper.miniMessage().deserialize(this.optionalTitle.get(relationalContext), relationalContext.combinedTagResolver()));
                 }
             }
         }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/TitleFunction.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/function/TitleFunction.java
@@ -39,16 +39,16 @@ public class TitleFunction<CTX extends Context> extends AbstractConditionalFunct
     public void runInternal(CTX ctx) {
         if (this.selector == null) {
             ctx.getOptionalParameter(DirectContextParameters.PLAYER).ifPresent(it -> it.sendTitle(
-                    AdventureHelper.miniMessage().deserialize(this.main.get(ctx), ctx.tagResolvers()),
-                    AdventureHelper.miniMessage().deserialize(this.sub.get(ctx), ctx.tagResolvers()),
+                    AdventureHelper.miniMessage().deserialize(this.main.get(ctx), ctx.combinedTagResolver()),
+                    AdventureHelper.miniMessage().deserialize(this.sub.get(ctx), ctx.combinedTagResolver()),
                     this.fadeIn.getInt(ctx), this.stay.getInt(ctx), this.fadeOut.getInt(ctx)
             ));
         } else {
             for (Player viewer : this.selector.get(ctx)) {
                 RelationalContext relationalContext = ViewerContext.of(ctx, PlayerOptionalContext.of(viewer, ContextHolder.EMPTY));
                 viewer.sendTitle(
-                        AdventureHelper.miniMessage().deserialize(this.main.get(relationalContext), relationalContext.tagResolvers()),
-                        AdventureHelper.miniMessage().deserialize(this.sub.get(relationalContext), relationalContext.tagResolvers()),
+                        AdventureHelper.miniMessage().deserialize(this.main.get(relationalContext), relationalContext.combinedTagResolver()),
+                        AdventureHelper.miniMessage().deserialize(this.sub.get(relationalContext), relationalContext.combinedTagResolver()),
                         this.fadeIn.getInt(relationalContext), this.stay.getInt(relationalContext), this.fadeOut.getInt(relationalContext)
                 );
             }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/number/ExpressionNumberProvider.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/number/ExpressionNumberProvider.java
@@ -21,7 +21,7 @@ public class ExpressionNumberProvider implements NumberProvider {
 
     @Override
     public float getFloat(Context context) {
-        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(this.expr, context.tagResolvers());
+        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(this.expr, context.combinedTagResolver());
         String resultString = AdventureHelper.plainTextContent(resultComponent);
         Expression expression = new Expression(resultString);
         try {
@@ -33,7 +33,7 @@ public class ExpressionNumberProvider implements NumberProvider {
 
     @Override
     public double getDouble(Context context) {
-        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(this.expr, context.tagResolvers());
+        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(this.expr, context.combinedTagResolver());
         String resultString = AdventureHelper.plainTextContent(resultComponent);
         Expression expression = new Expression(resultString);
         try {

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/text/TagTextProvider.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/text/TagTextProvider.java
@@ -18,7 +18,7 @@ public class TagTextProvider implements TextProvider {
 
     @Override
     public String get(Context context) {
-        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(this.text, context.tagResolvers());
+        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(this.text, context.combinedTagResolver());
         return AdventureHelper.plainTextContent(resultComponent);
     }
 

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/gui/category/ItemBrowserManagerImpl.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/gui/category/ItemBrowserManagerImpl.java
@@ -161,8 +161,8 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                 this.plugin.logger().warn("Can't not find item " + it.icon() + " for category icon");
                 return null;
             }
-            item.customNameJson(AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(it.displayName(), ItemBuildContext.EMPTY.tagResolvers())));
-            item.loreJson(it.displayLore().stream().map(lore -> AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(lore, ItemBuildContext.EMPTY.tagResolvers()))).toList());
+            item.customNameJson(AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(it.displayName(), ItemBuildContext.EMPTY.combinedTagResolver())));
+            item.loreJson(it.displayLore().stream().map(lore -> AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(lore, ItemBuildContext.EMPTY.combinedTagResolver()))).toList());
             return new ItemWithAction(item, (element, click) -> {
                 click.cancel();
                 player.playSound(Constants.SOUND_CLICK_BUTTON);
@@ -179,7 +179,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(Constants.BROWSER_TITLE, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(Constants.BROWSER_TITLE, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }
@@ -245,12 +245,12 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                 if (ItemUtils.isEmpty(item)) {
                     if (!subCategory.icon().equals(ItemKeys.AIR)) {
                         item = this.plugin.itemManager().createWrappedItem(ItemKeys.BARRIER, player);
-                        item.customNameJson(AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(subCategory.displayName(), ItemBuildContext.EMPTY.tagResolvers())));
-                        item.loreJson(subCategory.displayLore().stream().map(lore -> AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(lore, ItemBuildContext.EMPTY.tagResolvers()))).toList());
+                        item.customNameJson(AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(subCategory.displayName(), ItemBuildContext.EMPTY.combinedTagResolver())));
+                        item.loreJson(subCategory.displayLore().stream().map(lore -> AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(lore, ItemBuildContext.EMPTY.combinedTagResolver()))).toList());
                     }
                 } else {
-                    item.customNameJson(AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(subCategory.displayName(), ItemBuildContext.EMPTY.tagResolvers())));
-                    item.loreJson(subCategory.displayLore().stream().map(lore -> AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(lore, ItemBuildContext.EMPTY.tagResolvers()))).toList());
+                    item.customNameJson(AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(subCategory.displayName(), ItemBuildContext.EMPTY.combinedTagResolver())));
+                    item.loreJson(subCategory.displayLore().stream().map(lore -> AdventureHelper.componentToJson(AdventureHelper.miniMessage().deserialize(lore, ItemBuildContext.EMPTY.combinedTagResolver()))).toList());
                 }
                 return new ItemWithAction(item, (element, click) -> {
                     click.cancel();
@@ -321,7 +321,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(Constants.CATEGORY_TITLE, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(Constants.CATEGORY_TITLE, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }
@@ -382,7 +382,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_NONE_TITLE, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_NONE_TITLE, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }
@@ -576,7 +576,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_BREWING_TITLE, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_BREWING_TITLE, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }
@@ -776,7 +776,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_SMITHING_TRANSFORM_TITLE, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_SMITHING_TRANSFORM_TITLE, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }
@@ -909,7 +909,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_STONECUTTING_TITLE, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_STONECUTTING_TITLE, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }
@@ -1059,7 +1059,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(title, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(title, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }
@@ -1254,7 +1254,7 @@ public class ItemBrowserManagerImpl implements ItemBrowserManager {
                     }
                 })
                 .build()
-                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_CRAFTING_TITLE, PlayerOptionalContext.of(player).tagResolvers()))
+                .title(AdventureHelper.miniMessage().deserialize(Constants.RECIPE_CRAFTING_TITLE, PlayerOptionalContext.of(player).combinedTagResolver()))
                 .refresh()
                 .open(player);
     }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/ExpressionTag.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/ExpressionTag.java
@@ -34,7 +34,7 @@ public class ExpressionTag implements TagResolver {
         String format = arguments.popOr("No format provided").toString();
         String expr = arguments.popOr("No expression provided").toString();
 
-        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(expr, context.tagResolvers());
+        Component resultComponent = AdventureHelper.customMiniMessage().deserialize(expr, context.combinedTagResolver());
         String resultString = AdventureHelper.plainTextContent(resultComponent);
         Expression expression = new Expression(resultString);
 

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/GlobalVariableTag.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/GlobalVariableTag.java
@@ -32,14 +32,14 @@ public class GlobalVariableTag implements TagResolver {
             throw ctx.newException("Unknown variable: ", arguments);
         }
         if (!arguments.hasNext()) {
-            return Tag.selfClosingInserting(AdventureHelper.miniMessage().deserialize(value, this.context.tagResolvers()));
+            return Tag.selfClosingInserting(AdventureHelper.miniMessage().deserialize(value, this.context.combinedTagResolver()));
         } else {
             List<Component> args = new ArrayList<>();
             while (arguments.hasNext()) {
-                args.add(AdventureHelper.miniMessage().deserialize(arguments.popOr("No index argument variable id provided").toString(), this.context.tagResolvers()));
+                args.add(AdventureHelper.miniMessage().deserialize(arguments.popOr("No index argument variable id provided").toString(), this.context.combinedTagResolver()));
             }
             return Tag.selfClosingInserting(AdventureHelper.miniMessage().deserialize(value, TagResolver.builder()
-                    .resolvers(this.context.tagResolvers())
+                    .resolvers(this.context.combinedTagResolver())
                     .resolver(new IndexedArgumentTag(args))
                     .build()));
         }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/I18NTag.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/I18NTag.java
@@ -24,7 +24,7 @@ public class I18NTag implements TagResolver {
         }
         String i18nKey = arguments.popOr("No argument i18n key provided").toString();
         String translation = TranslationManager.instance().miniMessageTranslation(i18nKey);
-        return Tag.selfClosingInserting(AdventureHelper.miniMessage().deserialize(translation, this.context.tagResolvers()));
+        return Tag.selfClosingInserting(AdventureHelper.miniMessage().deserialize(translation, this.context.combinedTagResolver()));
     }
 
     @Override

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/NamedArgumentTag.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/NamedArgumentTag.java
@@ -31,7 +31,7 @@ public class NamedArgumentTag implements TagResolver {
         if (value == null) {
             value = arguments.popOr("No default value provided").toString();
         }
-        return Tag.selfClosingInserting(AdventureHelper.miniMessage().deserialize(String.valueOf(value), this.context.tagResolvers()));
+        return Tag.selfClosingInserting(AdventureHelper.miniMessage().deserialize(String.valueOf(value), this.context.combinedTagResolver()));
     }
 
     @Override

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/PlaceholderTag.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/PlaceholderTag.java
@@ -24,7 +24,7 @@ public class PlaceholderTag implements TagResolver {
             return null;
         }
         String rawArgument = arguments.popOr("No argument relational placeholder provided").toString();
-        if (rawArgument.contains("<")) rawArgument = AdventureHelper.resolvePlainStringTags(rawArgument, this.context.tagResolvers());
+        if (rawArgument.contains("<")) rawArgument = AdventureHelper.resolvePlainStringTags(rawArgument, this.context.combinedTagResolver());
         String placeholder = "%" + rawArgument + "%";
         String parsed = this.context instanceof PlayerOptionalContext playerOptionalContext ? CraftEngine.instance().compatibilityManager().parse(playerOptionalContext.player(), placeholder) : CraftEngine.instance().compatibilityManager().parse(null, placeholder);
         if (parsed.equals(placeholder)) {

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/RelationalPlaceholderTag.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/text/minimessage/RelationalPlaceholderTag.java
@@ -29,7 +29,7 @@ public class RelationalPlaceholderTag implements TagResolver {
             return null;
         }
         String rawArgument = arguments.popOr("No argument placeholder provided").toString();
-        if (rawArgument.contains("<")) rawArgument = AdventureHelper.resolvePlainStringTags(rawArgument, this.context.tagResolvers());
+        if (rawArgument.contains("<")) rawArgument = AdventureHelper.resolvePlainStringTags(rawArgument, this.context.combinedTagResolver());
         String placeholder = "%" + rawArgument + "%";
         String parsed = CraftEngine.instance().compatibilityManager().parse(this.player1, this.player2, placeholder);
         if (parsed.equals(placeholder)) {


### PR DESCRIPTION
这样开发者就可以把自定义的TagResolver塞进去了

btw使用`combinedTagResolver`代替原来的数组几乎没有性能开销，查阅Adventure代码可知解析MiniMessage传入TagResolver数组后也会被同下的方式合并为一个TagResolver
```java
default TagResolver combinedTagResolver() {
    return TagResolver.resolver(tagResolvers());
}
```