### PR TITLE
Dev sk

### DIFF
--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/SkriptHook.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/SkriptHook.java
@@ -1,12 +1,14 @@
 package net.momirealms.craftengine.bukkit.compatibility.skript;
 
 import net.momirealms.craftengine.bukkit.compatibility.skript.clazz.CraftEngineClasses;
+import net.momirealms.craftengine.bukkit.compatibility.skript.condition.CondIsCraftEngineHasBeenLoad;
 import net.momirealms.craftengine.bukkit.compatibility.skript.condition.CondIsCustomBlock;
 import net.momirealms.craftengine.bukkit.compatibility.skript.condition.CondIsCustomItem;
 import net.momirealms.craftengine.bukkit.compatibility.skript.condition.CondIsFurniture;
 import net.momirealms.craftengine.bukkit.compatibility.skript.effect.EffPlaceCustomBlock;
 import net.momirealms.craftengine.bukkit.compatibility.skript.effect.EffPlaceFurniture;
 import net.momirealms.craftengine.bukkit.compatibility.skript.effect.EffRemoveFurniture;
+import net.momirealms.craftengine.bukkit.compatibility.skript.event.EvtCraftEngineReload;
 import net.momirealms.craftengine.bukkit.compatibility.skript.event.EvtCustomBlock;
 import net.momirealms.craftengine.bukkit.compatibility.skript.event.EvtCustomClick;
 import net.momirealms.craftengine.bukkit.compatibility.skript.event.EvtCustomFurniture;
@@ -16,9 +18,11 @@ public class SkriptHook {
 
     public static void register() {
         CraftEngineClasses.register();
+        EvtCraftEngineReload.register();
         EvtCustomBlock.register();
         EvtCustomFurniture.register();
         EvtCustomClick.register();
+        CondIsCraftEngineHasBeenLoad.register();
         CondIsCustomBlock.register();
         CondIsFurniture.register();
         CondIsCustomItem.register();

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCraftEngineHasBeenLoad.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCraftEngineHasBeenLoad.java
@@ -1,0 +1,45 @@
+package net.momirealms.craftengine.bukkit.compatibility.skript.condition;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import net.momirealms.craftengine.bukkit.compatibility.skript.event.EvtCraftEngineReload;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("CraftEngine has been load")
+@Description({"Checks CraftEngine has been load."})
+@Since("1.0")
+public class CondIsCraftEngineHasBeenLoad extends Condition {
+
+    public static void register() {
+        Skript.registerCondition(CondIsCraftEngineHasBeenLoad.class,
+                "(ce|craft-engine) has been load[ed]",
+                "(ce|craft-engine) has not been load[ed] [yet]"
+        );
+    }
+
+    @Override
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        setNegated(matchedPattern == 1);
+        return true;
+    }
+
+    @Override
+    public boolean check(Event event) {
+        boolean beenLoad = EvtCraftEngineReload.hasBeenLoad();
+        return isNegated() ? !beenLoad : beenLoad;
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        return "craft-engine has " + (isNegated() ? "not " : "") + "been loaded";
+    }
+
+
+}

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCustomBlock.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCustomBlock.java
@@ -15,8 +15,8 @@ public class CondIsCustomBlock extends Condition {
 
     public static void register() {
         Skript.registerCondition(CondIsCustomBlock.class,
-                "%blocks% (is|are) custom block(s)",
-                "%blocks% (is|are)(n't| not) custom block(s)");
+                "%blocks% (is|are) (custom|ce|craft-engine) block(s)",
+                "%blocks% (is|are)(n't| not) (custom|ce|craft-engine) block(s)");
     }
 
     private Expression<Block> blocks;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCustomItem.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCustomItem.java
@@ -1,41 +1,65 @@
 package net.momirealms.craftengine.bukkit.compatibility.skript.condition;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.slot.Slot;
 import ch.njol.util.Kleenean;
 import net.momirealms.craftengine.bukkit.api.CraftEngineItems;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+@Name("Is CraftEngine Item")
+@Description({"Checks if the Item is CraftEngine item."})
+@Since("1.0")
 public class CondIsCustomItem extends Condition {
 
     public static void register() {
         Skript.registerCondition(CondIsCustomItem.class,
-                "%itemstacks% (is|are) custom item(s)",
-                "%itemstacks% (is|are)(n't| not) custom item(s)");
+                "%itemstack/itemtype/slot% (is [a[n]]|are) (custom|ce|craft-engine) item[s]",
+                "%itemstack/itemtype/slot% (isn't|is not|aren't|are not) [a[n]] (custom|ce|craft-engine) item[s]"
+        );
     }
 
-    private Expression<ItemStack> items;
-
-    @Override
-    public boolean check(Event event) {
-        return items.check(event, CraftEngineItems::isCustomItem, isNegated());
-    }
-
-    @Override
-    public String toString(@Nullable Event event, boolean debug) {
-        return PropertyCondition.toString(this, PropertyCondition.PropertyType.BE, event, debug, items, "itemstack");
-    }
+    private Expression<?> item;
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-        items = (Expression<ItemStack>) expressions[0];
-        setNegated(matchedPattern > 1);
+        item = expressions[0];
+        setNegated(matchedPattern == 1);
         return true;
+    }
+
+    @Override
+    public boolean check(Event event) {
+        Object single = item.getSingle(event);
+
+        ItemStack checkItemStack = null;
+        if (single instanceof ItemType itemType) {
+            checkItemStack = itemType.getTypes().getFirst().getStack();
+        } else if (single instanceof ItemStack itemStack) {
+            checkItemStack = itemStack;
+        } else if (single instanceof Slot slot) {
+            checkItemStack = slot.getItem();
+        }
+
+        if (checkItemStack == null) return isNegated() ? true : false;
+
+        boolean exists = CraftEngineItems.isCustomItem(checkItemStack);
+        if (!exists) return isNegated() ? true : false;
+        return isNegated() ? false : true;
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        return PropertyCondition.toString(this, PropertyCondition.PropertyType.BE, event, debug, item, "itemtypes");
     }
 }

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsFurniture.java
@@ -15,8 +15,8 @@ public class CondIsFurniture extends Condition {
 
     public static void register() {
         Skript.registerCondition(CondIsFurniture.class,
-                "%entities% (is|are) furniture",
-                "%entities% (is|are)(n't| not) furniture");
+                "%entities% (is|are) (custom|ce|craft-engine) furniture",
+                "%entities% (is|are)(n't| not) (custom|ce|craft-engine) furniture");
     }
 
     private Expression<Entity> entities;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffPlaceCustomBlock.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffPlaceCustomBlock.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 public class EffPlaceCustomBlock extends Effect {
 
     public static void register() {
-        Skript.registerEffect(EffPlaceCustomBlock.class, "place custom block %customblockstates% [%directions% %locations%]");
+        Skript.registerEffect(EffPlaceCustomBlock.class, "place (custom|ce|craft-engine) block %customblockstates% [at] [%directions% %locations%]");
     }
 
     private Expression<ImmutableBlockState> blocks;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffPlaceFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffPlaceFurniture.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 public class EffPlaceFurniture extends Effect {
 
     public static void register() {
-        Skript.registerEffect(EffPlaceFurniture.class, "place furniture %strings% [%directions% %locations%]");
+        Skript.registerEffect(EffPlaceFurniture.class, "place (custom|ce|craft-engine) furniture %strings% [at] [%directions% %locations%]");
     }
 
     private Expression<String> furniture;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffRemoveFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffRemoveFurniture.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 public class EffRemoveFurniture extends Effect {
 
     public static void register() {
-        Skript.registerEffect(EffRemoveFurniture.class, "remove furniture %entities%");
+        Skript.registerEffect(EffRemoveFurniture.class, "remove (custom|ce|craft-engine) furniture %entities%");
     }
 
     private Expression<Entity> entities;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCraftEngineReload.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCraftEngineReload.java
@@ -34,12 +34,15 @@ public class EvtCraftEngineReload extends SkriptEvent {
 
     @Override
     public boolean check(Event event) {
-        if (event instanceof CraftEngineReloadEvent reloadEvent) return false;
+        if (!(event instanceof CraftEngineReloadEvent reloadEvent)) {
+            return false;
+        }
         if (onlyCheckFirstCall) {
             if (hasBeenCalled) return false; // 如果 hasBeenCalled 已经为 true，代表已经调用过了, 故返回 false。
             hasBeenCalled = true;
             return true;
         }
+        hasBeenCalled = true;
         return true;
     }
 

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCraftEngineReload.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCraftEngineReload.java
@@ -1,0 +1,54 @@
+package net.momirealms.craftengine.bukkit.compatibility.skript.event;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser;
+import net.momirealms.craftengine.bukkit.api.event.CraftEngineReloadEvent;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("On CraftEngine Reload")
+@Description({"Fires when CraftEngine reload"})
+@Since("1.0")
+public class EvtCraftEngineReload extends SkriptEvent {
+
+    public static void register() {
+        Skript.registerEvent("CraftEngine Loaded", EvtCraftEngineReload.class, CraftEngineReloadEvent.class, "(ce|craft(engine|-engine)) [first] (load[ed]|reload)")
+                .description("Called when Craft-Engine resource loaded.");
+    }
+
+    private boolean onlyCheckFirstCall;
+    private static boolean hasBeenCalled = false;
+
+    @Override
+    public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parser) {
+        // 检查是否包含 "first" 关键词
+        String expr = parser.expr;
+        this.onlyCheckFirstCall = expr.contains("first");
+        return true;
+    }
+
+    @Override
+    public boolean check(Event event) {
+        if (event instanceof CraftEngineReloadEvent reloadEvent) return false;
+        if (onlyCheckFirstCall) {
+            if (hasBeenCalled) return false; // 如果 hasBeenCalled 已经为 true，代表已经调用过了, 故返回 false。
+            hasBeenCalled = true;
+            return true;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        return onlyCheckFirstCall ? "craftengine first load" : "craftengine reload";
+    }
+
+    public static boolean hasBeenLoad() {
+        return hasBeenCalled;
+    }
+}

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomBlock.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomBlock.java
@@ -1,6 +1,9 @@
 package net.momirealms.craftengine.bukkit.compatibility.skript.event;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
@@ -16,12 +19,15 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 @SuppressWarnings({"unchecked"})
+@Name("On Custom Block Place And Break")
+@Description({"Fires when a Custom block gets place and broken"})
+@Since("1.0")
 public class EvtCustomBlock extends SkriptEvent {
 
     public static void register() {
-        Skript.registerEvent("Break Custom Block", EvtCustomBlock.class, CustomBlockBreakEvent.class, "(break[ing]|1¦min(e|ing)) [[of] %-unsafeblockstatematchers%]")
+        Skript.registerEvent("Break Custom Block", EvtCustomBlock.class, CustomBlockBreakEvent.class, "(break[ing]|1¦min(e|ing)) of (custom|ce|craft-engine) block [[of] %-unsafeblockstatematchers%]")
                 .description("Called when a custom block is broken by a player. If you use 'on mine', only events where the broken block dropped something will call the trigger.");
-        Skript.registerEvent("Place Custom Block", EvtCustomBlock.class, CustomBlockPlaceEvent.class, "(plac(e|ing)|build[ing]) [[of] %-unsafeblockstatematchers%]")
+        Skript.registerEvent("Place Custom Block", EvtCustomBlock.class, CustomBlockPlaceEvent.class, "(plac(e|ing)|build[ing]) of (custom|ce|craft-engine) block [[of] %-unsafeblockstatematchers%]")
                 .description("Called when a player places a custom block.");
     }
 

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomClick.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomClick.java
@@ -3,6 +3,9 @@ package net.momirealms.craftengine.bukkit.compatibility.skript.event;
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.bukkitutil.ClickEventTracker;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
@@ -17,6 +20,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
+@Name("On Click with Custom Item")
+@Description({"Fires when click a custom item"})
+@Since("1.0")
 public class EvtCustomClick extends SkriptEvent {
 
     private final static int RIGHT = 1, LEFT = 2, ANY = RIGHT | LEFT;
@@ -25,8 +31,8 @@ public class EvtCustomClick extends SkriptEvent {
     @SuppressWarnings("unchecked")
     public static void register() {
         Skript.registerEvent("Interact Custom Block Furniture", EvtCustomClick.class, new Class[]{CustomBlockInteractEvent.class, FurnitureInteractEvent.class},
-                        "[(" + RIGHT + ":right|" + LEFT + ":left)(| |-)][mouse(| |-)]click[ing] [on %-unsafeblockstatematchers/strings%] [(with|using|holding) %-itemtype%]",
-                        "[(" + RIGHT + ":right|" + LEFT + ":left)(| |-)][mouse(| |-)]click[ing] (with|using|holding) %itemtype% on %unsafeblockstatematchers/strings%");
+                        "[(" + RIGHT + ":right|" + LEFT + ":left)(| |-)][mouse(| |-)]click[ing] of (custom|ce|craft-engine) item[s] [on %-unsafeblockstatematchers/strings%] [(with|using|holding) %-itemtype%]",
+                        "[(" + RIGHT + ":right|" + LEFT + ":left)(| |-)][mouse(| |-)]click[ing] of (custom|ce|craft-engine) item[s] (with|using|holding) %itemtype% on %unsafeblockstatematchers/strings%");
     }
 
     private @Nullable Literal<?> type;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomFurniture.java
@@ -1,6 +1,9 @@
 package net.momirealms.craftengine.bukkit.compatibility.skript.event;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
@@ -12,12 +15,15 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 @SuppressWarnings({"unchecked"})
+@Name("On Custom Furniture Place And Break")
+@Description({"Fires when a Custom furniture gets place and broken"})
+@Since("1.0")
 public class EvtCustomFurniture extends SkriptEvent {
 
     public static void register() {
-        Skript.registerEvent("Break Furniture", EvtCustomFurniture.class, FurnitureBreakEvent.class, "(break[ing]) [[of] %-strings%]")
+        Skript.registerEvent("Break Furniture", EvtCustomFurniture.class, FurnitureBreakEvent.class, "(break[ing]) of (custom|ce|craft-engine) furniture[s] [[of] %-strings%]")
                 .description("Called when a furniture is broken by a player.");
-        Skript.registerEvent("Place Furniture", EvtCustomFurniture.class, FurniturePlaceEvent.class, "(plac(e|ing)|build[ing]) [[of] %-strings%]")
+        Skript.registerEvent("Place Furniture", EvtCustomFurniture.class, FurniturePlaceEvent.class, "(plac(e|ing)|build[ing]) of (custom|ce|craft-engine) furniture[s] [[of] %-strings%]")
                 .description("Called when a player places a furniture.");
     }
 

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprBlockCustomBlockID.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprBlockCustomBlockID.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public class ExprBlockCustomBlockID extends SimplePropertyExpression<Object, String> {
 
     public static void register() {
-        register(ExprBlockCustomBlockID.class, String.class, "custom block id", "blocks/blockdata/customblockstates");
+        register(ExprBlockCustomBlockID.class, String.class, "(custom|ce|craft-engine) block [namespace] id", "blocks/blockdata/customblockstates");
     }
 
     @Override

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprBlockCustomBlockState.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprBlockCustomBlockState.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 public class ExprBlockCustomBlockState extends SimplePropertyExpression<Object, ImmutableBlockState> {
 
     public static void register() {
-        register(ExprBlockCustomBlockState.class, ImmutableBlockState.class, "custom block[ ]state", "blocks/blockdata");
+        register(ExprBlockCustomBlockState.class, ImmutableBlockState.class, "(custom|ce|craft-engine) block[ ]state", "blocks/blockdata");
     }
 
     @Override

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprEntityFurnitureID.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprEntityFurnitureID.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public class ExprEntityFurnitureID extends SimplePropertyExpression<Object, String> {
 
     public static void register() {
-        register(ExprEntityFurnitureID.class, String.class, "furniture id", "entities");
+        register(ExprEntityFurnitureID.class, String.class, "(custom|ce|craft-engine) furniture [namespace] id", "entities");
     }
 
     @Override


### PR DESCRIPTION
主要调整了语句语法, 重写了关于CustomItem相关的类; 

1. 允许将custom替换成 ce / craft-engine , 避免和其他扩展的语句冲突
```
set {_item} to custom item "default:topaz"
set {_item} to ce item with namespace id "default:topaz"
```

2. 为CondIsCustomItem和ExprItemCustomItemID添加了从 itemstack, itemtype, slot 3个来源进行判断的支持; 
```
send "检查: %(player's tool)'s ce item id%" to player
send "检查: %{_checkItem}'s ce item id%" to player
send "检查: %CraftEngineItems.byId(Key.of("default:topaz")).buildItemStack()'s ce item id%" to player

send "检查: %craft-engine item namespace id of player's tool%" to player
send "检查: %craft-engine item namespace id of {_checkItem}%" to player
send "检查: %craft-engine item namespace id of ce item "default:topaz"%" to player     
```

3. 添加了EvtCraftEngineReload, 支持监听CraftEngineReloadEvent事件; 同时支持判断当前load事件是否是第一次从sk监听;
```
on ce first load:
    send "当服务端启动, CE第一次初始化完成后触发" to console

on ce reload:
    send "当ce reload时触发" to console
```

4. 添加了CondIsCraftEngineHasBeenLoad, 用于判断ce当前是否已经加载完成
```
on load:
    if ce has been loaded:
        send "当脚本加载, 并且CE初始化完成时触发" to console
    if ce has not been loaded yet:
        send "当脚本加载, 并且CE还未初始化完成时触发" to console
```

5.为 on place/break/click监听语句都添加了 of (ce|craft-engine) block/furniture , 主要是解决和Skript 2.12.1版本后本身自带的语句冲突, 导致部分工作出错.
```
on click of craft-engine:
    send "你点击了一下ce的方块/家具" to player
    
on break of craft-engine block default:palm_log:
    send "你破坏了一个ce的方块"
    
on place of craft-engine furniture default:bench:
    send "你放置了一个ce的家具"
```