### PR TITLE
修复一些Skript的表达式问题

### DIFF
--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCraftEngineHasBeenLoad.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCraftEngineHasBeenLoad.java
@@ -19,14 +19,15 @@ public class CondIsCraftEngineHasBeenLoad extends Condition {
 
     public static void register() {
         Skript.registerCondition(CondIsCraftEngineHasBeenLoad.class,
-                "(ce|craft-engine) has been load[ed]",
-                "(ce|craft-engine) has not been load[ed] [yet]"
+                "(ce|craft[-]engine) (has been|is) load[ed]",
+                "(ce|craft[-]engine) (has not been|is not) load[ed] [yet]",
+                "(ce|craft[-]engine) (hasn't been|isn't) load[ed] [yet]"
         );
     }
 
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-        setNegated(matchedPattern == 1);
+        setNegated(matchedPattern >= 1);
         return true;
     }
 
@@ -38,7 +39,7 @@ public class CondIsCraftEngineHasBeenLoad extends Condition {
 
     @Override
     public String toString(@Nullable Event event, boolean debug) {
-        return "craft-engine has " + (isNegated() ? "not " : "") + "been loaded";
+        return "craft-engine " + (isNegated() ? "is not" : "is") + " loaded";
     }
 
 

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCustomBlock.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsCustomBlock.java
@@ -15,8 +15,8 @@ public class CondIsCustomBlock extends Condition {
 
     public static void register() {
         Skript.registerCondition(CondIsCustomBlock.class,
-                "%blocks% (is|are) (custom|ce|craft-engine) block(s)",
-                "%blocks% (is|are)(n't| not) (custom|ce|craft-engine) block(s)");
+                "%blocks% (is|are) [a[n]] (custom|ce|craft-engine) block[s]",
+                "%blocks% (is|are) (n't| not) [a[n]] (custom|ce|craft-engine) block[s]");
     }
 
     private Expression<Block> blocks;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/condition/CondIsFurniture.java
@@ -7,23 +7,29 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.util.Kleenean;
 import net.momirealms.craftengine.bukkit.api.CraftEngineFurniture;
+import net.momirealms.craftengine.bukkit.entity.furniture.BukkitFurniture;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Predicate;
 
 public class CondIsFurniture extends Condition {
 
     public static void register() {
         Skript.registerCondition(CondIsFurniture.class,
-                "%entities% (is|are) (custom|ce|craft-engine) furniture",
-                "%entities% (is|are)(n't| not) (custom|ce|craft-engine) furniture");
+                "%entities% (is|are) [a[n]] [(custom|ce|craft-engine)] furniture[s]",
+                "%entities% (is|are) (n't| not) [a[n]] [(custom|ce|craft-engine)] furniture[s]");
     }
 
     private Expression<Entity> entities;
 
     @Override
     public boolean check(Event event) {
-        return entities.check(event, CraftEngineFurniture::isFurniture, isNegated());
+        return entities.check(event, entity -> {
+            BukkitFurniture baseEntity = CraftEngineFurniture.getLoadedFurnitureByBaseEntity(entity);
+            return baseEntity != null;
+        }, isNegated());
     }
 
     @Override

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffPlaceFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffPlaceFurniture.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 public class EffPlaceFurniture extends Effect {
 
     public static void register() {
-        Skript.registerEffect(EffPlaceFurniture.class, "place (custom|ce|craft-engine) furniture %strings% [at] [%directions% %locations%]");
+        Skript.registerEffect(EffPlaceFurniture.class, "place [(custom|ce|craft-engine)] furniture[s] %strings% [at] [%directions% %locations%]");
     }
 
     private Expression<String> furniture;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffRemoveFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/effect/EffRemoveFurniture.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 public class EffRemoveFurniture extends Effect {
 
     public static void register() {
-        Skript.registerEffect(EffRemoveFurniture.class, "remove (custom|ce|craft-engine) furniture %entities%");
+        Skript.registerEffect(EffRemoveFurniture.class, "remove [(custom|ce|craft-engine)] furniture %entities%");
     }
 
     private Expression<Entity> entities;
@@ -22,11 +22,9 @@ public class EffRemoveFurniture extends Effect {
     @Override
     protected void execute(Event e) {
         for (Entity entity : entities.getArray(e)) {
-            if (CraftEngineFurniture.isFurniture(entity)) {
-                Furniture bukkitFurniture = CraftEngineFurniture.getLoadedFurnitureByBaseEntity(entity);
-                if (bukkitFurniture != null) {
-                    bukkitFurniture.destroy();
-                }
+            Furniture bukkitFurniture = CraftEngineFurniture.getLoadedFurnitureByBaseEntity(entity);
+            if (bukkitFurniture != null) {
+                bukkitFurniture.destroy();
             }
         }
     }

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomBlock.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomBlock.java
@@ -7,12 +7,20 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.registrations.EventValues;
 import net.momirealms.craftengine.bukkit.api.event.CustomBlockBreakEvent;
 import net.momirealms.craftengine.bukkit.api.event.CustomBlockPlaceEvent;
+import net.momirealms.craftengine.bukkit.api.event.FurnitureBreakEvent;
+import net.momirealms.craftengine.bukkit.api.event.FurniturePlaceEvent;
 import net.momirealms.craftengine.bukkit.util.BlockStateUtils;
 import net.momirealms.craftengine.core.block.ImmutableBlockState;
 import net.momirealms.craftengine.core.block.UnsafeBlockStateMatcher;
 import net.momirealms.craftengine.core.entity.player.InteractionHand;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,10 +33,19 @@ import java.util.Arrays;
 public class EvtCustomBlock extends SkriptEvent {
 
     public static void register() {
-        Skript.registerEvent("Break Custom Block", EvtCustomBlock.class, CustomBlockBreakEvent.class, "(break[ing]|1¦min(e|ing)) of (custom|ce|craft-engine) block [[of] %-unsafeblockstatematchers%]")
+        Skript.registerEvent("Break Custom Block", EvtCustomBlock.class, CustomBlockBreakEvent.class, "(break[ing]|1¦min(e|ing)) of (custom|ce|craft-engine) block[s] [[of] %-unsafeblockstatematchers%]")
                 .description("Called when a custom block is broken by a player. If you use 'on mine', only events where the broken block dropped something will call the trigger.");
-        Skript.registerEvent("Place Custom Block", EvtCustomBlock.class, CustomBlockPlaceEvent.class, "(plac(e|ing)|build[ing]) of (custom|ce|craft-engine) block [[of] %-unsafeblockstatematchers%]")
+        EventValues.registerEventValue(CustomBlockBreakEvent.class, Location.class, CustomBlockBreakEvent::location, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockBreakEvent.class, Player.class, CustomBlockBreakEvent::getPlayer, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockBreakEvent.class, Block.class, CustomBlockBreakEvent::bukkitBlock, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockBreakEvent.class, World.class, event -> event.location().getWorld(), EventValues.TIME_NOW);
+
+        Skript.registerEvent("Place Custom Block", EvtCustomBlock.class, CustomBlockPlaceEvent.class, "(plac(e|ing)|build[ing]) of (custom|ce|craft-engine) block[s] [[of] %-unsafeblockstatematchers%]")
                 .description("Called when a player places a custom block.");
+        EventValues.registerEventValue(CustomBlockPlaceEvent.class, Location.class, CustomBlockPlaceEvent::location, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockPlaceEvent.class, Player.class, CustomBlockPlaceEvent::player, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockPlaceEvent.class, Block.class, CustomBlockPlaceEvent::bukkitBlock, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockPlaceEvent.class, World.class, event -> event.location().getWorld(), EventValues.TIME_NOW);
     }
 
     @Nullable

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomClick.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomClick.java
@@ -9,19 +9,26 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.registrations.EventValues;
 import net.momirealms.craftengine.bukkit.api.event.CustomBlockInteractEvent;
+import net.momirealms.craftengine.bukkit.api.event.FurnitureBreakEvent;
 import net.momirealms.craftengine.bukkit.api.event.FurnitureInteractEvent;
 import net.momirealms.craftengine.core.block.ImmutableBlockState;
 import net.momirealms.craftengine.core.block.UnsafeBlockStateMatcher;
 import net.momirealms.craftengine.core.entity.player.InteractionHand;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.EquipmentSlot;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
-@Name("On Click with Custom Item")
-@Description({"Fires when click a custom item"})
+@Name("On Click on Custom Block and Furniture")
+@Description({"Fires when click on custom block and furniture"})
 @Since("1.0")
 public class EvtCustomClick extends SkriptEvent {
 
@@ -33,6 +40,18 @@ public class EvtCustomClick extends SkriptEvent {
         Skript.registerEvent("Interact Custom Block Furniture", EvtCustomClick.class, new Class[]{CustomBlockInteractEvent.class, FurnitureInteractEvent.class},
                         "[(" + RIGHT + ":right|" + LEFT + ":left)(| |-)][mouse(| |-)]click[ing] of (ce|craft-engine) [on %-unsafeblockstatematchers/strings%] [(with|using|holding) %-itemtype%]",
                         "[(" + RIGHT + ":right|" + LEFT + ":left)(| |-)][mouse(| |-)]click[ing] of (ce|craft-engine) (with|using|holding) %itemtype% on %unsafeblockstatematchers/strings%");
+
+        EventValues.registerEventValue(CustomBlockInteractEvent.class, Location.class, CustomBlockInteractEvent::location, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockInteractEvent.class, Player.class, CustomBlockInteractEvent::player, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockInteractEvent.class, Block.class, CustomBlockInteractEvent::bukkitBlock, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockInteractEvent.class, Entity.class, event -> null, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockInteractEvent.class, World.class, event -> event.location().getWorld(), EventValues.TIME_NOW);
+
+        EventValues.registerEventValue(FurnitureInteractEvent.class, Location.class, FurnitureInteractEvent::location, EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurnitureInteractEvent.class, Player.class, FurnitureInteractEvent::player, EventValues.TIME_NOW);
+        EventValues.registerEventValue(CustomBlockInteractEvent.class, Block.class, event -> null, EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurnitureInteractEvent.class, Entity.class, event -> event.furniture().baseEntity(), EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurnitureInteractEvent.class, World.class, event -> event.location().getWorld(), EventValues.TIME_NOW);
     }
 
     private @Nullable Literal<?> type;

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomFurniture.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/event/EvtCustomFurniture.java
@@ -7,8 +7,15 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.registrations.EventValues;
+import io.papermc.paper.event.player.PlayerTrackEntityEvent;
+import net.momirealms.craftengine.bukkit.api.event.CustomBlockInteractEvent;
 import net.momirealms.craftengine.bukkit.api.event.FurnitureBreakEvent;
 import net.momirealms.craftengine.bukkit.api.event.FurniturePlaceEvent;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,10 +28,19 @@ import java.util.Arrays;
 public class EvtCustomFurniture extends SkriptEvent {
 
     public static void register() {
-        Skript.registerEvent("Break Furniture", EvtCustomFurniture.class, FurnitureBreakEvent.class, "(break[ing]) of (custom|ce|craft-engine) furniture[s] [[of] %-strings%]")
+        Skript.registerEvent("Break Furniture", EvtCustomFurniture.class, FurnitureBreakEvent.class, "(break[ing]) of [(custom|ce|craft-engine)] furniture[s] [[of] %-strings%]")
                 .description("Called when a furniture is broken by a player.");
-        Skript.registerEvent("Place Furniture", EvtCustomFurniture.class, FurniturePlaceEvent.class, "(plac(e|ing)|build[ing]) of (custom|ce|craft-engine) furniture[s] [[of] %-strings%]")
+        EventValues.registerEventValue(FurnitureBreakEvent.class, Location.class, FurnitureBreakEvent::location, EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurnitureBreakEvent.class, Player.class, FurnitureBreakEvent::player, EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurnitureBreakEvent.class, Entity.class, event -> event.furniture().baseEntity(), EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurnitureBreakEvent.class, World.class, event -> event.location().getWorld(), EventValues.TIME_NOW);
+
+        Skript.registerEvent("Place Furniture", EvtCustomFurniture.class, FurniturePlaceEvent.class, "(plac(e|ing)|build[ing]) of [(custom|ce|craft-engine)] furniture[s] [[of] %-strings%]")
                 .description("Called when a player places a furniture.");
+        EventValues.registerEventValue(FurniturePlaceEvent.class, Location.class, FurniturePlaceEvent::location, EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurniturePlaceEvent.class, Player.class, FurniturePlaceEvent::player, EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurniturePlaceEvent.class, Entity.class, event -> event.furniture().baseEntity(), EventValues.TIME_NOW);
+        EventValues.registerEventValue(FurniturePlaceEvent.class, World.class, event -> event.location().getWorld(), EventValues.TIME_NOW);
     }
 
     @Nullable

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprEntityFurnitureID.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/skript/expression/ExprEntityFurnitureID.java
@@ -10,12 +10,12 @@ import java.util.Optional;
 public class ExprEntityFurnitureID extends SimplePropertyExpression<Object, String> {
 
     public static void register() {
-        register(ExprEntityFurnitureID.class, String.class, "(custom|ce|craft-engine) furniture [namespace] id", "entities");
+        register(ExprEntityFurnitureID.class, String.class, "[(custom|ce|craft-engine)] furniture [namespace] id", "entities");
     }
 
     @Override
     public @Nullable String convert(Object object) {
-        if (object instanceof Entity entity && CraftEngineFurniture.isFurniture(entity)) {
+        if (object instanceof Entity entity) {
             return Optional.ofNullable(CraftEngineFurniture.getLoadedFurnitureByBaseEntity(entity))
                     .map(it -> it.id().toString())
                     .orElse(null);


### PR DESCRIPTION
1.修复家具表达式判断实体是否是家具时有误的问题;
2.显式为事件添加事件字段;
3.调整家具相关表达式, custom ce 关键字变得可选了;
4.改改我的垃圾英语;