### PR TITLE
Coral blocks in mappings

### DIFF
--- a/common-files/src/main/resources/mappings.yml
+++ b/common-files/src/main/resources/mappings.yml
@@ -4320,6 +4320,89 @@ minecraft:heavy_weighted_pressure_plate[power=13]: minecraft:heavy_weighted_pres
 minecraft:heavy_weighted_pressure_plate[power=14]: minecraft:heavy_weighted_pressure_plate[power=1]
 minecraft:heavy_weighted_pressure_plate[power=15]: minecraft:heavy_weighted_pressure_plate[power=1]
 
+# # Corals
+# # Coral blocks are ideal for creating water blocks or wall-mounted blocks. But this means that the corals can no longer dry out.
+
+# # Brain Coral
+# minecraft:dead_brain_coral[waterlogged=false]: minecraft:brain_coral[waterlogged=false]
+# minecraft:dead_brain_coral[waterlogged=true]: minecraft:brain_coral[waterlogged=true]
+
+# minecraft:dead_brain_coral_fan[waterlogged=false]: minecraft:brain_coral_fan[waterlogged=false]
+# minecraft:dead_brain_coral_fan[waterlogged=true]: minecraft:brain_coral_fan[waterlogged=true]
+
+# minecraft:dead_brain_coral_wall_fan[waterlogged=false,facing=east]: minecraft:brain_coral_wall_fan[waterlogged=false,facing=east]
+# minecraft:dead_brain_coral_wall_fan[waterlogged=false,facing=north]: minecraft:brain_coral_wall_fan[waterlogged=false,facing=north]
+# minecraft:dead_brain_coral_wall_fan[waterlogged=false,facing=south]: minecraft:brain_coral_wall_fan[waterlogged=false,facing=south]
+# minecraft:dead_brain_coral_wall_fan[waterlogged=false,facing=west]: minecraft:brain_coral_wall_fan[waterlogged=false,facing=west]
+# minecraft:dead_brain_coral_wall_fan[waterlogged=true,facing=east]: minecraft:brain_coral_wall_fan[waterlogged=true,facing=east]
+# minecraft:dead_brain_coral_wall_fan[waterlogged=true,facing=north]: minecraft:brain_coral_wall_fan[waterlogged=true,facing=north]
+# minecraft:dead_brain_coral_wall_fan[waterlogged=true,facing=south]: minecraft:brain_coral_wall_fan[waterlogged=true,facing=south]
+# minecraft:dead_brain_coral_wall_fan[waterlogged=true,facing=west]: minecraft:brain_coral_wall_fan[waterlogged=true,facing=west]
+
+# # Bubble Coral
+# minecraft:dead_bubble_coral[waterlogged=false]: minecraft:bubble_coral[waterlogged=false]
+# minecraft:dead_bubble_coral[waterlogged=true]: minecraft:bubble_coral[waterlogged=true]
+
+# minecraft:dead_bubble_coral_fan[waterlogged=false]: minecraft:bubble_coral_fan[waterlogged=false]
+# minecraft:dead_bubble_coral_fan[waterlogged=true]: minecraft:bubble_coral_fan[waterlogged=true]
+
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=false,facing=east]: minecraft:bubble_coral_wall_fan[waterlogged=false,facing=east]
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=false,facing=north]: minecraft:bubble_coral_wall_fan[waterlogged=false,facing=north]
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=false,facing=south]: minecraft:bubble_coral_wall_fan[waterlogged=false,facing=south]
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=false,facing=west]: minecraft:bubble_coral_wall_fan[waterlogged=false,facing=west]
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=true,facing=east]: minecraft:bubble_coral_wall_fan[waterlogged=true,facing=east]
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=true,facing=north]: minecraft:bubble_coral_wall_fan[waterlogged=true,facing=north]
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=true,facing=south]: minecraft:bubble_coral_wall_fan[waterlogged=true,facing=south]
+# minecraft:dead_bubble_coral_wall_fan[waterlogged=true,facing=west]: minecraft:bubble_coral_wall_fan[waterlogged=true,facing=west]
+
+# # Fire Coral
+# minecraft:dead_fire_coral[waterlogged=false]: minecraft:fire_coral[waterlogged=false]
+# minecraft:dead_fire_coral[waterlogged=true]: minecraft:fire_coral[waterlogged=true]
+
+# minecraft:dead_fire_coral_fan[waterlogged=false]: minecraft:fire_coral_fan[waterlogged=false]
+# minecraft:dead_fire_coral_fan[waterlogged=true]: minecraft:fire_coral_fan[waterlogged=true]
+
+# minecraft:dead_fire_coral_wall_fan[waterlogged=false,facing=east]: minecraft:fire_coral_wall_fan[waterlogged=false,facing=east]
+# minecraft:dead_fire_coral_wall_fan[waterlogged=false,facing=north]: minecraft:fire_coral_wall_fan[waterlogged=false,facing=north]
+# minecraft:dead_fire_coral_wall_fan[waterlogged=false,facing=south]: minecraft:fire_coral_wall_fan[waterlogged=false,facing=south]
+# minecraft:dead_fire_coral_wall_fan[waterlogged=false,facing=west]: minecraft:fire_coral_wall_fan[waterlogged=false,facing=west]
+# minecraft:dead_fire_coral_wall_fan[waterlogged=true,facing=east]: minecraft:fire_coral_wall_fan[waterlogged=true,facing=east]
+# minecraft:dead_fire_coral_wall_fan[waterlogged=true,facing=north]: minecraft:fire_coral_wall_fan[waterlogged=true,facing=north]
+# minecraft:dead_fire_coral_wall_fan[waterlogged=true,facing=south]: minecraft:fire_coral_wall_fan[waterlogged=true,facing=south]
+# minecraft:dead_fire_coral_wall_fan[waterlogged=true,facing=west]: minecraft:fire_coral_wall_fan[waterlogged=true,facing=west]
+
+# # Horn Coral
+# minecraft:dead_horn_coral[waterlogged=false]: minecraft:horn_coral[waterlogged=false]
+# minecraft:dead_horn_coral[waterlogged=true]: minecraft:horn_coral[waterlogged=true]
+
+# minecraft:dead_horn_coral_fan[waterlogged=false]: minecraft:horn_coral_fan[waterlogged=false]
+# minecraft:dead_horn_coral_fan[waterlogged=true]: minecraft:horn_coral_fan[waterlogged=true]
+
+# minecraft:dead_horn_coral_wall_fan[waterlogged=false,facing=east]: minecraft:horn_coral_wall_fan[waterlogged=false,facing=east]
+# minecraft:dead_horn_coral_wall_fan[waterlogged=false,facing=north]: minecraft:horn_coral_wall_fan[waterlogged=false,facing=north]
+# minecraft:dead_horn_coral_wall_fan[waterlogged=false,facing=south]: minecraft:horn_coral_wall_fan[waterlogged=false,facing=south]
+# minecraft:dead_horn_coral_wall_fan[waterlogged=false,facing=west]: minecraft:horn_coral_wall_fan[waterlogged=false,facing=west]
+# minecraft:dead_horn_coral_wall_fan[waterlogged=true,facing=east]: minecraft:horn_coral_wall_fan[waterlogged=true,facing=east]
+# minecraft:dead_horn_coral_wall_fan[waterlogged=true,facing=north]: minecraft:horn_coral_wall_fan[waterlogged=true,facing=north]
+# minecraft:dead_horn_coral_wall_fan[waterlogged=true,facing=south]: minecraft:horn_coral_wall_fan[waterlogged=true,facing=south]
+# minecraft:dead_horn_coral_wall_fan[waterlogged=true,facing=west]: minecraft:horn_coral_wall_fan[waterlogged=true,facing=west]
+
+# # Tube Coral
+# minecraft:dead_tube_coral[waterlogged=false]: minecraft:tube_coral[waterlogged=false]
+# minecraft:dead_tube_coral[waterlogged=true]: minecraft:tube_coral[waterlogged=true]
+
+# minecraft:dead_tube_coral_fan[waterlogged=false]: minecraft:tube_coral_fan[waterlogged=false]
+# minecraft:dead_tube_coral_fan[waterlogged=true]: minecraft:tube_coral_fan[waterlogged=true]
+
+# minecraft:dead_tube_coral_wall_fan[waterlogged=false,facing=east]: minecraft:tube_coral_wall_fan[waterlogged=false,facing=east]
+# minecraft:dead_tube_coral_wall_fan[waterlogged=false,facing=north]: minecraft:tube_coral_wall_fan[waterlogged=false,facing=north]
+# minecraft:dead_tube_coral_wall_fan[waterlogged=false,facing=south]: minecraft:tube_coral_wall_fan[waterlogged=false,facing=south]
+# minecraft:dead_tube_coral_wall_fan[waterlogged=false,facing=west]: minecraft:tube_coral_wall_fan[waterlogged=false,facing=west]
+# minecraft:dead_tube_coral_wall_fan[waterlogged=true,facing=east]: minecraft:tube_coral_wall_fan[waterlogged=true,facing=east]
+# minecraft:dead_tube_coral_wall_fan[waterlogged=true,facing=north]: minecraft:tube_coral_wall_fan[waterlogged=true,facing=north]
+# minecraft:dead_tube_coral_wall_fan[waterlogged=true,facing=south]: minecraft:tube_coral_wall_fan[waterlogged=true,facing=south]
+# minecraft:dead_tube_coral_wall_fan[waterlogged=true,facing=west]: minecraft:tube_coral_wall_fan[waterlogged=true,facing=west]
+
 #### Chorus Plant ####
 # Chorus Plant does support transparent textures, but man... its hitbox is super weird. You're probably better off using leaves.
 # minecraft:chorus_plant[down=false,east=false,north=false,south=false,up=false,west=false]: minecraft:chorus_plant[down=true,east=true,north=true,south=true,up=true,west=true]


### PR DESCRIPTION
Added support for all types of corals to the mappings.yml file
Marked the change as documented because this feature may not be suitable for everyone as it disables coral drying.
And these blocks are great for creating wall blocks or underwater blocks and plants. 🪸