### PR TITLE
fix(bukkit): 修复构建 MythicMobs 物品

### DIFF
--- a/bukkit/compatibility/build.gradle.kts
+++ b/bukkit/compatibility/build.gradle.kts
@@ -15,6 +15,7 @@ repositories {
     maven("https://repo.dmulloy2.net/repository/public/") // mcmmo required
     maven("https://repo.auxilor.io/repository/maven-public/") // eco
     maven("https://repo.hiusers.com/releases") // zaphkiel
+    maven("https://jitpack.io") // sxitem
 }
 
 dependencies {
@@ -72,6 +73,10 @@ dependencies {
     compileOnly("ink.ptms:ZaphkielAPI:2.1.0")
     // WorldGuard
     compileOnly(files("${rootProject.rootDir}/libs/worldguard-bukkit-7.0.14-dist.jar"))
+    // HeadDatabase
+    compileOnly("com.arcaniax:HeadDatabase-API:1.3.2")
+    // SXItem
+    compileOnly("com.github.Saukiya:SX-Item:4.4.6")
 }
 
 java {

--- a/bukkit/compatibility/build.gradle.kts
+++ b/bukkit/compatibility/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
     maven("https://repo.dmulloy2.net/repository/public/") // mcmmo required
     maven("https://repo.auxilor.io/repository/maven-public/") // eco
     maven("https://repo.hiusers.com/releases") // zaphkiel
-    maven("https://jitpack.io") // sxitem
+    maven("https://jitpack.io") // sxitem slimefun
 }
 
 dependencies {
@@ -77,6 +77,8 @@ dependencies {
     compileOnly("com.arcaniax:HeadDatabase-API:1.3.2")
     // SXItem
     compileOnly("com.github.Saukiya:SX-Item:4.4.6")
+    // Slimefun
+    compileOnly("io.github.Slimefun:Slimefun4:RC-32")
 }
 
 java {

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/BukkitCompatibilityManager.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/BukkitCompatibilityManager.java
@@ -263,6 +263,14 @@ public class BukkitCompatibilityManager implements CompatibilityManager {
             itemManager.registerExternalItemSource(new ZaphkielSource());
             logHook("Zaphkiel");
         }
+        if (this.isPluginEnabled("HeadDatabase")) {
+            itemManager.registerExternalItemSource(new HeadDatabaseSource());
+            logHook("HeadDatabase");
+        }
+        if (this.isPluginEnabled("SX-Item")) {
+            itemManager.registerExternalItemSource(new SXItemSource());
+            logHook("SX-Item");
+        }
     }
 
     private Plugin getPlugin(String name) {

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/BukkitCompatibilityManager.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/BukkitCompatibilityManager.java
@@ -271,6 +271,10 @@ public class BukkitCompatibilityManager implements CompatibilityManager {
             itemManager.registerExternalItemSource(new SXItemSource());
             logHook("SX-Item");
         }
+        if (this.isPluginEnabled("Slimefun")) {
+            itemManager.registerExternalItemSource(new SlimefunSource());
+            logHook("Slimefun");
+        }
     }
 
     private Plugin getPlugin(String name) {

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/HeadDatabaseSource.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/HeadDatabaseSource.java
@@ -1,0 +1,33 @@
+package net.momirealms.craftengine.bukkit.compatibility.item;
+
+import net.momirealms.craftengine.core.item.ExternalItemSource;
+import net.momirealms.craftengine.core.item.ItemBuildContext;
+import me.arcaniax.hdb.api.HeadDatabaseAPI;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public class HeadDatabaseSource implements ExternalItemSource<ItemStack> {
+    private HeadDatabaseAPI api;
+
+    @Override
+    public String plugin() {
+        return "headdatabase";
+    }
+
+    @Nullable
+    @Override
+    public ItemStack build(String id, ItemBuildContext context) {
+        if (api == null) {
+            api = new HeadDatabaseAPI();
+        }
+        return api.getItemHead(id);
+    }
+
+    @Override
+    public String id(ItemStack item) {
+        if (api == null) {
+            api = new HeadDatabaseAPI();
+        }
+        return api.getItemID(item);
+    }
+}

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/MythicMobsSource.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/MythicMobsSource.java
@@ -1,10 +1,17 @@
 package net.momirealms.craftengine.bukkit.compatibility.item;
 
+import io.lumine.mythic.api.adapters.AbstractPlayer;
+import io.lumine.mythic.api.skills.SkillCaster;
+import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.MythicBukkit;
+import io.lumine.mythic.core.drops.DropMetadataImpl;
 import net.momirealms.craftengine.core.item.ExternalItemSource;
 import net.momirealms.craftengine.core.item.ItemBuildContext;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 public class MythicMobsSource implements ExternalItemSource<ItemStack> {
     private MythicBukkit mythicBukkit;
@@ -20,7 +27,18 @@ public class MythicMobsSource implements ExternalItemSource<ItemStack> {
         if (mythicBukkit == null || mythicBukkit.isClosed()) {
             this.mythicBukkit = MythicBukkit.inst();
         }
-        return mythicBukkit.getItemManager().getItemStack(id);
+        return Optional.ofNullable(context.player())
+                .map(p -> (Player) p.platformPlayer())
+                .map(p -> {
+                    AbstractPlayer target = BukkitAdapter.adapt(p);
+                    SkillCaster caster = mythicBukkit.getSkillManager().getCaster(target);
+                    DropMetadataImpl meta = new DropMetadataImpl(caster, target);
+                    return mythicBukkit.getItemManager().getItem(id)
+                            .map(i -> i.generateItemStack(meta, 1))
+                            .map(BukkitAdapter::adapt)
+                            .orElse(null);
+                })
+                .orElseGet(() -> mythicBukkit.getItemManager().getItemStack(id));
     }
 
     @Override

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/SXItemSource.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/SXItemSource.java
@@ -1,0 +1,29 @@
+package net.momirealms.craftengine.bukkit.compatibility.item;
+
+import github.saukiya.sxitem.SXItem;
+import net.momirealms.craftengine.core.item.ExternalItemSource;
+import net.momirealms.craftengine.core.item.ItemBuildContext;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class SXItemSource implements ExternalItemSource<ItemStack> {
+
+    @Override
+    public String plugin() {
+        return "sxitem";
+    }
+
+    @Nullable
+    @Override
+    public ItemStack build(String id, ItemBuildContext context) {
+        return SXItem.getItemManager().getItem(id, Optional.ofNullable(context.player()).map(p -> (Player) p.platformPlayer()).orElse(null));
+    }
+
+    @Override
+    public String id(ItemStack item) {
+        return SXItem.getItemManager().getItemKey(item);
+    }
+}

--- a/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/SlimefunSource.java
+++ b/bukkit/compatibility/src/main/java/net/momirealms/craftengine/bukkit/compatibility/item/SlimefunSource.java
@@ -1,0 +1,28 @@
+package net.momirealms.craftengine.bukkit.compatibility.item;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import net.momirealms.craftengine.core.item.ExternalItemSource;
+import net.momirealms.craftengine.core.item.ItemBuildContext;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class SlimefunSource implements ExternalItemSource<ItemStack> {
+
+    @Override
+    public String plugin() {
+        return "slimefun";
+    }
+
+    @Nullable
+    @Override
+    public ItemStack build(String id, ItemBuildContext context) {
+        return Optional.ofNullable(SlimefunItem.getById(id)).map(SlimefunItem::getItem).orElse(null);
+    }
+
+    @Override
+    public String id(ItemStack item) {
+        return Optional.ofNullable(SlimefunItem.getByItem(item)).map(SlimefunItem::getId).orElse(null);
+    }
+}

--- a/core/src/main/java/net/momirealms/craftengine/core/util/ConcurrentUUID2ReferenceChainedHashTable.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/util/ConcurrentUUID2ReferenceChainedHashTable.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
  * Concurrent hashtable implementation supporting mapping UUID values onto non-null Object
  * values with support for multiple writer and multiple reader threads.
  */
+@SuppressWarnings("unchecked")
 public class ConcurrentUUID2ReferenceChainedHashTable<V> implements Iterable<ConcurrentUUID2ReferenceChainedHashTable.TableEntry<V>> {
     protected static final int DEFAULT_CAPACITY = 16;
     protected static final float DEFAULT_LOAD_FACTOR = 0.75f;


### PR DESCRIPTION
- 传递 Player 对象到 MythicMobs 以便解析占位符