### PR TITLE
Add new auto-state: leaves_no_tint

### DIFF
--- a/common-files/src/main/resources/resources/default/configuration/blocks/palm_tree.yml
+++ b/common-files/src/main/resources/resources/default/configuration/blocks/palm_tree.yml
@@ -198,10 +198,7 @@ items:
     material: oak_leaves
     data:
       item-name: <!i><i18n:item.palm_leaves>
-      block-state:
-        distance: '1'
-        persistent: 'false'
-        waterlogged: 'false'
+      block-state: default:palm_leaves[persistent=true,waterlogged=false,distance=7]
     model:
       type: minecraft:model
       path: minecraft:item/custom/palm_leaves
@@ -223,7 +220,7 @@ items:
         settings:
           template: default:settings/leaves
         states:
-          template: default:block_state/leaves
+          template: default:block_state/tintable_leaves
           arguments:
             model_path: minecraft:block/custom/palm_leaves
             texture_path: minecraft:block/custom/palm_leaves

--- a/common-files/src/main/resources/resources/default/configuration/templates.yml
+++ b/common-files/src/main/resources/resources/default/configuration/templates.yml
@@ -898,8 +898,7 @@ templates#block_states:
         appearance: axisY
       axis=z:
         appearance: axisZ
-  # leaves block
-  default:block_state/leaves:
+  default:block_state/__leaves__:
     properties:
       waterlogged:
         type: boolean
@@ -913,7 +912,7 @@ templates#block_states:
         range: 1~7
     appearances:
       default:
-        auto-state: leaves
+        auto-state: ${auto_state}
         model:
           path: ${model_path}
           generation:
@@ -921,7 +920,7 @@ templates#block_states:
             textures:
               all: ${texture_path}
       waterlogged:
-        auto-state: waterlogged_leaves
+        auto-state: waterlogged_${auto_state}
         model:
           path: ${model_path}
     variants:
@@ -936,44 +935,21 @@ templates#block_states:
       distance=7,persistent=false:
         settings:
           is-randomly-ticking: true
-  # leaves (no tint) block
+  # any leaves block
   default:block_state/leaves:
-    properties:
-      waterlogged:
-        type: boolean
-        default: false
-      persistent:
-        type: boolean
-        default: true
-      distance:
-        type: int
-        default: 7
-        range: 1~7
-    appearances:
-      default:
-        auto-state: leaves_no_tint
-        model:
-          path: ${model_path}
-          generation:
-            parent: minecraft:block/leaves
-            textures:
-              all: ${texture_path}
-      waterlogged:
-        auto-state: waterlogged_leaves_no_tint
-        model:
-          path: ${model_path}
-    variants:
-      waterlogged=false:
-        appearance: default
-      waterlogged=true:
-        appearance: waterlogged
-        settings:
-          resistance: 1200.0
-          burnable: false
-          fluid-state: water
-      distance=7,persistent=false:
-        settings:
-          is-randomly-ticking: true
+    template: default:block_state/__leaves__
+    arguments:
+      auto_state: leaves
+  # tintable leaves block
+  default:block_state/tintable_leaves:
+    template: default:block_state/__leaves__
+    arguments:
+      auto_state: tintable_leaves
+  # non-tintable leaves block
+  default:block_state/non_tintable_leaves:
+    template: default:block_state/__leaves__
+    arguments:
+      auto_state: non_tintable_leaves
   # trapdoor block
   default:block_state/trapdoor:
     properties:

--- a/core/src/main/java/net/momirealms/craftengine/core/block/AutoStateGroup.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/block/AutoStateGroup.java
@@ -9,22 +9,33 @@ import java.util.*;
 import java.util.function.Predicate;
 
 public enum AutoStateGroup {
-    LEAVES("leaves",
+    NON_TINTABLE_LEAVES(List.of("no_tint_leaves", "leaves_no_tint", "non_tintable_leaves"),
+            Set.of(BlockKeys.SPRUCE_LEAVES, BlockKeys.CHERRY_LEAVES, BlockKeys.PALE_OAK_LEAVES, BlockKeys.AZALEA_LEAVES, BlockKeys.FLOWERING_AZALEA_LEAVES),
+            (w) -> !(boolean) w.getProperty("waterlogged")
+    ),
+    WATERLOGGED_NON_TINTABLE_LEAVES(
+            List.of("waterlogged_no_tint_leaves", "waterlogged_leaves_no_tint", "waterlogged_non_tintable_leaves"),
+            Set.of(BlockKeys.SPRUCE_LEAVES, BlockKeys.CHERRY_LEAVES, BlockKeys.PALE_OAK_LEAVES, BlockKeys.AZALEA_LEAVES, BlockKeys.FLOWERING_AZALEA_LEAVES),
+            (w) -> w.getProperty("waterlogged")
+    ),
+    TINTABLE_LEAVES("tintable_leaves",
             Set.of(BlockKeys.OAK_LEAVES, BlockKeys.BIRCH_LEAVES, BlockKeys.JUNGLE_LEAVES, BlockKeys.ACACIA_LEAVES, BlockKeys.DARK_OAK_LEAVES, BlockKeys.MANGROVE_LEAVES),
+            (w) -> !(boolean) w.getProperty("waterlogged")
+    ),
+    WATERLOGGED_TINTABLE_LEAVES(
+            "waterlogged_tintable_leaves",
+            Set.of(BlockKeys.OAK_LEAVES, BlockKeys.BIRCH_LEAVES, BlockKeys.JUNGLE_LEAVES, BlockKeys.ACACIA_LEAVES, BlockKeys.DARK_OAK_LEAVES, BlockKeys.MANGROVE_LEAVES),
+            (w) -> w.getProperty("waterlogged")
+    ),
+    LEAVES("leaves",
+            Set.of(BlockKeys.OAK_LEAVES, BlockKeys.BIRCH_LEAVES, BlockKeys.JUNGLE_LEAVES, BlockKeys.ACACIA_LEAVES, BlockKeys.DARK_OAK_LEAVES, BlockKeys.MANGROVE_LEAVES,
+                    BlockKeys.SPRUCE_LEAVES, BlockKeys.CHERRY_LEAVES, BlockKeys.PALE_OAK_LEAVES, BlockKeys.AZALEA_LEAVES, BlockKeys.FLOWERING_AZALEA_LEAVES),
             (w) -> !(boolean) w.getProperty("waterlogged")
     ),
     WATERLOGGED_LEAVES(
             "waterlogged_leaves",
-            Set.of(BlockKeys.OAK_LEAVES, BlockKeys.BIRCH_LEAVES, BlockKeys.JUNGLE_LEAVES, BlockKeys.ACACIA_LEAVES, BlockKeys.DARK_OAK_LEAVES, BlockKeys.MANGROVE_LEAVES),
-            (w) -> w.getProperty("waterlogged")
-    ),
-    LEAVES_NO_TINT("leaves_no_tint",
-            Set.of(BlockKeys.SPRUCE_LEAVES, BlockKeys.CHERRY_LEAVES, BlockKeys.PALE_OAK_LEAVES, BlockKeys.AZALEA_LEAVES, BlockKeys.FLOWERING_AZALEA_LEAVES),
-            (w) -> !(boolean) w.getProperty("waterlogged")
-    ),
-    WATERLOGGED_LEAVES_NO_TINT(
-            "waterlogged_leaves_no_tint",
-            Set.of(BlockKeys.SPRUCE_LEAVES, BlockKeys.CHERRY_LEAVES, BlockKeys.PALE_OAK_LEAVES, BlockKeys.AZALEA_LEAVES, BlockKeys.FLOWERING_AZALEA_LEAVES),
+            Set.of(BlockKeys.OAK_LEAVES, BlockKeys.BIRCH_LEAVES, BlockKeys.JUNGLE_LEAVES, BlockKeys.ACACIA_LEAVES, BlockKeys.DARK_OAK_LEAVES, BlockKeys.MANGROVE_LEAVES,
+                    BlockKeys.SPRUCE_LEAVES, BlockKeys.CHERRY_LEAVES, BlockKeys.PALE_OAK_LEAVES, BlockKeys.AZALEA_LEAVES, BlockKeys.FLOWERING_AZALEA_LEAVES),
             (w) -> w.getProperty("waterlogged")
     ),
     LOWER_TRIPWIRE("lower_tripwire", Set.of(BlockKeys.TRIPWIRE), (w) -> w.getProperty("attached")),
@@ -41,12 +52,18 @@ public enum AutoStateGroup {
     SOLID("solid", Set.of(BlockKeys.BROWN_MUSHROOM_BLOCK, BlockKeys.RED_MUSHROOM_BLOCK, BlockKeys.MUSHROOM_STEM, BlockKeys.NOTE_BLOCK), (w) -> true);
 
     private final Set<Key> blocks;
-    private final String id;
+    private final List<String> id;
     private final Predicate<BlockStateWrapper> predicate;
     private final List<BlockStateCandidate> candidates = new ArrayList<>();
     private int pointer;
 
     AutoStateGroup(String id, Set<Key> blocks, Predicate<BlockStateWrapper> predicate) {
+        this.id = List.of(id);
+        this.blocks = blocks;
+        this.predicate = predicate;
+    }
+
+    AutoStateGroup(List<String> id, Set<Key> blocks, Predicate<BlockStateWrapper> predicate) {
         this.id = id;
         this.blocks = blocks;
         this.predicate = predicate;
@@ -89,6 +106,10 @@ public enum AutoStateGroup {
     }
 
     public String id() {
+        return id.getFirst();
+    }
+
+    public List<String> ids() {
         return id;
     }
 
@@ -97,10 +118,11 @@ public enum AutoStateGroup {
 
     static {
         for (AutoStateGroup group : AutoStateGroup.values()) {
-            BY_ID.put(group.id(), group);
-            BY_ID.put(group.id().toUpperCase(Locale.ROOT), group);
-            for (Key key : group.blocks) {
-                BY_BLOCKS.computeIfAbsent(key, k -> new ArrayList<>(4)).add(group);
+            for (String id : group.ids()) {
+                BY_ID.put(id, group);
+                for (Key key : group.blocks) {
+                    BY_BLOCKS.computeIfAbsent(key, k -> new ArrayList<>(4)).add(group);
+                }
             }
         }
     }


### PR DESCRIPTION
Added new auto-state value: `leaves_no_tint` to fix unpredictable leaves block generation

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eb50cb73-c24b-4f87-86e2-c4479650659f" />
