### PR TITLE
fix: persist potion_contents for furniture display

### DIFF
--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/entity/furniture/element/ArmorStandFurnitureElementConfig.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/entity/furniture/element/ArmorStandFurnitureElementConfig.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import net.momirealms.craftengine.bukkit.entity.data.ArmorStandData;
 import net.momirealms.craftengine.bukkit.entity.data.BaseEntityData;
 import net.momirealms.craftengine.bukkit.item.BukkitItemManager;
+import net.momirealms.craftengine.bukkit.item.DataComponentTypes;
 import net.momirealms.craftengine.core.entity.furniture.Furniture;
 import net.momirealms.craftengine.core.entity.furniture.FurnitureColorSource;
 import net.momirealms.craftengine.core.entity.furniture.element.FurnitureElementConfig;
@@ -83,6 +84,9 @@ public final class ArmorStandFurnitureElementConfig implements FurnitureElementC
                     false,
                     false
             )));
+            if (DataComponentTypes.POTION_CONTENTS != null) {
+                Optional.ofNullable(colorSource.potionContents()).ifPresent(contents -> wrappedItem.setComponent(DataComponentTypes.POTION_CONTENTS, contents));
+            }
         }
         return Optional.ofNullable(wrappedItem).orElseGet(() -> BukkitItemManager.instance().createWrappedItem(ItemKeys.BARRIER, null));
     }

--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/entity/furniture/element/ItemDisplayFurnitureElementConfig.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/entity/furniture/element/ItemDisplayFurnitureElementConfig.java
@@ -3,6 +3,7 @@ package net.momirealms.craftengine.bukkit.entity.furniture.element;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import net.momirealms.craftengine.bukkit.entity.data.ItemDisplayEntityData;
 import net.momirealms.craftengine.bukkit.item.BukkitItemManager;
+import net.momirealms.craftengine.bukkit.item.DataComponentTypes;
 import net.momirealms.craftengine.core.entity.display.Billboard;
 import net.momirealms.craftengine.core.entity.display.ItemDisplayContext;
 import net.momirealms.craftengine.core.entity.furniture.Furniture;
@@ -102,6 +103,9 @@ public final class ItemDisplayFurnitureElementConfig implements FurnitureElement
                         false,
                         false
                 )));
+                if (DataComponentTypes.POTION_CONTENTS != null) {
+                    Optional.ofNullable(colorSource.potionContents()).ifPresent(contents -> wrappedItem.setComponent(DataComponentTypes.POTION_CONTENTS, contents));
+                }
             }
             return Optional.ofNullable(wrappedItem).orElseGet(() -> BukkitItemManager.instance().createWrappedItem(ItemKeys.BARRIER, null));
         };

--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/entity/furniture/element/ItemFurnitureElementConfig.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/entity/furniture/element/ItemFurnitureElementConfig.java
@@ -3,6 +3,7 @@ package net.momirealms.craftengine.bukkit.entity.furniture.element;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import net.momirealms.craftengine.bukkit.entity.data.ItemEntityData;
 import net.momirealms.craftengine.bukkit.item.BukkitItemManager;
+import net.momirealms.craftengine.bukkit.item.DataComponentTypes;
 import net.momirealms.craftengine.core.entity.furniture.Furniture;
 import net.momirealms.craftengine.core.entity.furniture.FurnitureColorSource;
 import net.momirealms.craftengine.core.entity.furniture.element.FurnitureElementConfig;
@@ -58,6 +59,9 @@ public final class ItemFurnitureElementConfig implements FurnitureElementConfig<
                         false,
                         false
                 )));
+                if (DataComponentTypes.POTION_CONTENTS != null) {
+                    Optional.ofNullable(colorSource.potionContents()).ifPresent(contents -> wrappedItem.setComponent(DataComponentTypes.POTION_CONTENTS, contents));
+                }
             }
             return Optional.ofNullable(wrappedItem).orElseGet(() -> BukkitItemManager.instance().createWrappedItem(ItemKeys.BARRIER, null));
         };

--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/item/DataComponentTypes.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/item/DataComponentTypes.java
@@ -28,6 +28,7 @@ public final class DataComponentTypes {
     public static final Object CUSTOM_DATA = byId(DataComponentKeys.CUSTOM_DATA);
     public static final Object PROFILE = byId(DataComponentKeys.PROFILE);
     public static final Object DYED_COLOR = byId(DataComponentKeys.DYED_COLOR);
+    public static final Object POTION_CONTENTS = byId(DataComponentKeys.POTION_CONTENTS);
     public static final Object DEATH_PROTECTION = byId(DataComponentKeys.DEATH_PROTECTION);
     public static final Object FIREWORK_EXPLOSION = byId(DataComponentKeys.FIREWORK_EXPLOSION);
     public static final Object BUNDLE_CONTENTS = byId(DataComponentKeys.BUNDLE_CONTENTS);

--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/item/behavior/FurnitureItemBehavior.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/item/behavior/FurnitureItemBehavior.java
@@ -9,6 +9,7 @@ import net.momirealms.craftengine.bukkit.nms.FastNMS;
 import net.momirealms.craftengine.bukkit.plugin.BukkitCraftEngine;
 import net.momirealms.craftengine.bukkit.util.EventUtils;
 import net.momirealms.craftengine.bukkit.util.LocationUtils;
+import net.momirealms.craftengine.bukkit.item.DataComponentTypes;
 import net.momirealms.craftengine.core.entity.furniture.*;
 import net.momirealms.craftengine.core.entity.furniture.hitbox.FurnitureHitBoxConfig;
 import net.momirealms.craftengine.core.entity.player.InteractionResult;
@@ -178,6 +179,9 @@ public class FurnitureItemBehavior extends ItemBehavior {
         dataAccessor.setItem(item.copyWithCount(1));
         dataAccessor.setDyedColor(item.dyedColor().orElse(null));
         dataAccessor.setFireworkExplosionColors(item.fireworkExplosion().map(explosion -> explosion.colors().toIntArray()).orElse(null));
+        if (DataComponentTypes.POTION_CONTENTS != null) {
+            dataAccessor.setPotionContents(item.getSparrowNBTComponent(DataComponentTypes.POTION_CONTENTS));
+        }
         // 放置家具
         BukkitFurniture bukkitFurniture = BukkitFurnitureManager.instance().place(furnitureLocation.clone(), customFurniture, dataAccessor, false);
         // 触发放置事件

--- a/core/src/main/java/net/momirealms/craftengine/core/entity/furniture/FurnitureColorSource.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/entity/furniture/FurnitureColorSource.java
@@ -1,6 +1,7 @@
 package net.momirealms.craftengine.core.entity.furniture;
 
 import net.momirealms.craftengine.core.util.Color;
+import net.momirealms.sparrow.nbt.Tag;
 
-public record FurnitureColorSource(Color dyedColor, int[] fireworkColors) {
+public record FurnitureColorSource(Color dyedColor, int[] fireworkColors, Tag potionContents) {
 }

--- a/core/src/main/java/net/momirealms/craftengine/core/entity/furniture/FurnitureDataAccessor.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/entity/furniture/FurnitureDataAccessor.java
@@ -17,6 +17,7 @@ public final class FurnitureDataAccessor {
     public static final String ITEM = "item";
     public static final String DYED_COLOR = "dyed_color";
     public static final String FIREWORK_EXPLOSION_COLORS = "firework_explosion_colors";
+    public static final String POTION_CONTENTS = "potion_contents";
     public static final String VARIANT = "variant";
     @ApiStatus.Obsolete
     public static final String ANCHOR_TYPE = "anchor_type";
@@ -75,12 +76,30 @@ public final class FurnitureDataAccessor {
     }
 
     public FurnitureColorSource getColorSource() {
-        return new FurnitureColorSource(dyedColor().orElse(null), fireworkExplosionColors().orElse(null));
+        return new FurnitureColorSource(
+                dyedColor().orElse(null),
+                fireworkExplosionColors().orElse(null),
+                potionContents().orElse(null)
+        );
     }
 
     public Optional<int[]> fireworkExplosionColors() {
         if (this.data.containsKey(FIREWORK_EXPLOSION_COLORS)) return Optional.of(this.data.getIntArray(FIREWORK_EXPLOSION_COLORS));
         return Optional.empty();
+    }
+
+    public Optional<Tag> potionContents() {
+        Tag tag = this.data.get(POTION_CONTENTS);
+        if (tag == null) return Optional.empty();
+        return Optional.of(tag.copy());
+    }
+
+    public void setPotionContents(@Nullable Tag tag) {
+        if (tag == null) {
+            this.data.remove(POTION_CONTENTS);
+            return;
+        }
+        this.data.put(POTION_CONTENTS, tag.copy());
     }
 
     public void setFireworkExplosionColors(int[] colors) {


### PR DESCRIPTION
  ## Summary
  - Save potion_contents when placing furniture items
  - Re-apply potion_contents on display item creation when apply-dyed-color is enabled
  - Keep behavior consistent with dyedColor/firework colors

  ## Why
  Potion color lives in the potion_contents component. It was not persisted or restored for furniture displays, so the
  item fell back to the model default color.