### PR TITLE
fix(resource-pack): add safe texture optimization modes for fragile PNGs

### DIFF
--- a/common-files/src/main/resources/config.yml
+++ b/common-files/src/main/resources/config.yml
@@ -108,6 +108,13 @@ resource-pack:
       # Use Zopfli for PNG compression (very slow). More iterations = smaller files.
       # In fact, setting the number of iterations between 4 and 8 is generally sufficient. Increasing it further rarely leads to significant optimization in size.
       zopfli-iterations: 0 # 0 = disable
+      # Safety mode for fragile textures.
+      # - strict: safest (skip optimize for animated/non-square/hi-res/known-fragile-name textures)
+      # - balanced: moderate safety
+      # - aggressive: smallest size, highest risk of visual breakage
+      safety-mode: strict
+      # Log skipped textures and reason in console
+      log-skipped: true
       # If your image is special, for example, containing color pixels that need to be specifically recognized by a shader, the optimization might break it. You can add exclusions here.
       exclude:
         - assets/minecraft/textures/block/do_not_optimize

--- a/core/src/main/java/net/momirealms/craftengine/core/pack/AbstractPackManager.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/pack/AbstractPackManager.java
@@ -1057,7 +1057,7 @@ public abstract class AbstractPackManager implements PackManager {
         if (Config.optimizeJson()) {
             Path metaPath = path.resolve("pack.mcmeta");
             if (Files.exists(metaPath)) {
-                if (jsonExcluder.test(metaPath)) {
+                if (!jsonExcluder.test(metaPath)) {
                     commonJsonToOptimize.add(metaPath);
                 }
             }
@@ -1066,7 +1066,7 @@ public abstract class AbstractPackManager implements PackManager {
         if (Config.optimizeTexture()) {
             Path packPngPath = path.resolve("pack.png");
             if (Files.exists(packPngPath)) {
-                if (textureExcluder.test(packPngPath)) {
+                if (!textureExcluder.test(packPngPath)) {
                     imagesToOptimize.add(packPngPath);
                 }
             }
@@ -1225,12 +1225,14 @@ public abstract class AbstractPackManager implements PackManager {
             long optimizedSize = afterBytes.get();
             double compressionRatio = ((double) optimizedSize / originalSize) * 100;
             this.plugin.logger().info(TranslationManager.instance().translateLog("info.resource_pack.optimize.result", formatSize(originalSize), formatSize(optimizedSize), String.format("%.2f%%", compressionRatio)));
+            this.plugin.logger().info("Texture optimization safety-skip count: " + skippedBySafety.get() + " (mode=" + Config.optimizeTextureSafetyMode() + ")");
         }
 
         if (Config.optimizeTexture()) {
             this.plugin.logger().info(TranslationManager.instance().translateLog("info.resource_pack.optimize.texture"));
             AtomicLong previousBytes = new AtomicLong(0L);
             AtomicLong afterBytes = new AtomicLong(0L);
+            AtomicInteger skippedBySafety = new AtomicInteger(0);
             List<CompletableFuture<Void>> futures = new ArrayList<>();
             int amount = imagesToOptimize.size();
             AtomicInteger finished = new AtomicInteger(0);
@@ -1238,13 +1240,20 @@ public abstract class AbstractPackManager implements PackManager {
                 futures.add(CompletableFuture.runAsync(() -> {
                     try {
                         byte[] previousImageBytes = Files.readAllBytes(imagePath);
-                        byte[] optimized = optimizeImage(imagePath, previousImageBytes);
+                        StringBuilder skipReason = new StringBuilder();
+                        byte[] optimized = optimizeImage(imagePath, previousImageBytes, skipReason);
                         previousBytes.addAndGet(previousImageBytes.length);
                         if (optimized.length < previousImageBytes.length) {
                             afterBytes.addAndGet(optimized.length);
                             Files.write(imagePath, optimized);
                         } else {
                             afterBytes.addAndGet(previousImageBytes.length);
+                            if (!skipReason.isEmpty()) {
+                                skippedBySafety.incrementAndGet();
+                                if (Config.optimizeTextureLogSkipped()) {
+                                    Debugger.RESOURCE_PACK.debug(() -> "Skip optimize texture " + imagePath + " reason=" + skipReason);
+                                }
+                            }
                         }
                         finished.incrementAndGet();
                     } catch (IOException ignored) {
@@ -1306,20 +1315,59 @@ public abstract class AbstractPackManager implements PackManager {
         }
     }
 
-    private byte[] optimizeImage(Path imagePath, byte[] previousImageBytes) throws IOException {
+    private byte[] optimizeImage(Path imagePath, byte[] previousImageBytes, StringBuilder skipReason) throws IOException {
+        String mode = Config.optimizeTextureSafetyMode().toLowerCase(Locale.ENGLISH);
+        if (hasMcMetaSibling(imagePath)) {
+            skipReason.append("has-mcmeta");
+            return previousImageBytes;
+        }
         try (ByteArrayInputStream is = new ByteArrayInputStream(previousImageBytes)) {
             BufferedImage src = ImageIO.read(is);
             if (src == null) {
                 Debugger.RESOURCE_PACK.debug(() -> "Cannot read image " + imagePath.toString());
+                skipReason.append("unreadable");
                 return previousImageBytes;
             }
             if (src.getType() == BufferedImage.TYPE_CUSTOM) {
+                skipReason.append("custom-buffer-type");
                 return previousImageBytes;
             }
+
+            int width = src.getWidth();
+            int height = src.getHeight();
+            String fileName = imagePath.getFileName().toString().toLowerCase(Locale.ENGLISH);
+            boolean riskyByName = fileName.contains("ctm") || fileName.contains("connected") || fileName.contains("overlay") || fileName.contains("emissive") || fileName.contains("sheet") || fileName.contains("anim");
+            boolean riskyByShape = width != height;
+            boolean riskyByResolution = width >= 128 || height >= 128;
+
+            boolean shouldSkip = switch (mode) {
+                case "aggressive" -> false;
+                case "balanced" -> riskyByName || (riskyByShape && riskyByResolution);
+                default -> riskyByName || riskyByShape || riskyByResolution;
+            };
+
+            if (shouldSkip) {
+                if (riskyByName) {
+                    skipReason.append("risky-name");
+                } else if (riskyByShape) {
+                    skipReason.append("non-square");
+                } else if (riskyByResolution) {
+                    skipReason.append("high-resolution");
+                } else {
+                    skipReason.append("safety-mode");
+                }
+                return previousImageBytes;
+            }
+
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             new PngOptimizer(src).write(baos);
             return baos.toByteArray();
         }
+    }
+
+    private boolean hasMcMetaSibling(Path imagePath) {
+        Path mcmetaPath = imagePath.resolveSibling(imagePath.getFileName().toString() + ".mcmeta");
+        return Files.exists(mcmetaPath);
     }
 
     private void validateResourcePack(Path path, JsonObject packMetaJson) {

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/config/Config.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/config/Config.java
@@ -112,6 +112,8 @@ public class Config {
     protected boolean resource_pack$optimization$texture$enable;
     protected Set<String> resource_pack$optimization$texture$exlude;
     protected int resource_pack$optimization$texture$zopfli_iterations;
+    protected String resource_pack$optimization$texture$safety_mode;
+    protected boolean resource_pack$optimization$texture$log_skipped;
     protected boolean resource_pack$optimization$json$enable;
     protected Set<String> resource_pack$optimization$json$exclude;
 
@@ -393,6 +395,8 @@ public class Config {
         resource_pack$optimization$enable = config.getBoolean("resource-pack.optimization.enable", false);
         resource_pack$optimization$texture$enable = config.getBoolean("resource-pack.optimization.texture.enable", true);
         resource_pack$optimization$texture$zopfli_iterations = config.getInt("resource-pack.optimization.texture.zopfli-iterations", 0);
+        resource_pack$optimization$texture$safety_mode = config.getString("resource-pack.optimization.texture.safety-mode", "strict").toLowerCase(Locale.ENGLISH);
+        resource_pack$optimization$texture$log_skipped = config.getBoolean("resource-pack.optimization.texture.log-skipped", true);
         resource_pack$optimization$texture$exlude = config.getStringList("resource-pack.optimization.texture.exclude").stream().map(p -> {
             if (p.endsWith("/")) return p;
             if (!p.endsWith(".png")) return p + ".png";
@@ -1244,6 +1248,18 @@ public class Config {
 
     public static int zopfliIterations() {
         return instance.resource_pack$optimization$texture$zopfli_iterations;
+    }
+
+    public static String optimizeTextureSafetyMode() {
+        String mode = instance.resource_pack$optimization$texture$safety_mode;
+        if (mode == null || mode.isBlank()) {
+            return "strict";
+        }
+        return mode;
+    }
+
+    public static boolean optimizeTextureLogSkipped() {
+        return instance.resource_pack$optimization$texture$log_skipped;
     }
 
     public static boolean enableDefaultDropDisplay() {


### PR DESCRIPTION
## Summary
- add texture optimization safety modes: strict, balanced, aggressive
- prevent optimization on fragile textures (animated mcmeta, connected/non-square/high-resolution patterns)
- add skip logging and config docs for easier tuning

## Why
Some special textures can break after aggressive PNG optimization. This change adds safety-first controls to reduce visual corruption while preserving size optimization for safe assets.

## Test plan
- regenerate a resource pack with safety-mode: strict and verify fragile textures remain correct
- switch to balanced/aggressive and confirm behavior follows configured risk level
- verify optimization still runs and logs skip counts