### PR TITLE
Fix bootstrapping in dev env

### DIFF
--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/plugin/classpath/BukkitClassPathAppender.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/plugin/classpath/BukkitClassPathAppender.java
@@ -15,6 +15,7 @@ public final class BukkitClassPathAppender implements ClassPathAppender {
     public BukkitClassPathAppender() {
         ClassLoader bukkitClassLoader = Bukkit.class.getClassLoader();
 
+        // production env, server launched with a real jar file
         URLClassLoader urlClassLoader = findURLClassLoader(bukkitClassLoader);
         if (urlClassLoader != null) {
             URLClassLoaderAccess access = URLClassLoaderAccess.create(urlClassLoader);
@@ -28,6 +29,7 @@ public final class BukkitClassPathAppender implements ClassPathAppender {
             return;
         }
 
+        // fallback, we are in the development environment
         JdkBuiltinClassPathAppender jdkBuiltinAppender =
                 JdkBuiltinClassPathAppender.createIfSupported(bukkitClassLoader);
 

--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/plugin/classpath/BukkitClassPathAppender.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/plugin/classpath/BukkitClassPathAppender.java
@@ -1,6 +1,7 @@
 package net.momirealms.craftengine.bukkit.plugin.classpath;
 
 import net.momirealms.craftengine.core.plugin.classpath.ClassPathAppender;
+import net.momirealms.craftengine.core.plugin.classpath.JdkBuiltinClassPathAppender;
 import net.momirealms.craftengine.core.plugin.classpath.URLClassLoaderAccess;
 import org.bukkit.Bukkit;
 
@@ -9,31 +10,49 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 
 public final class BukkitClassPathAppender implements ClassPathAppender {
-    private final URLClassLoaderAccess libraryClassLoaderAccess;
+    private final ClassPathAppender delegate;
 
     public BukkitClassPathAppender() {
-        // 这个类加载器用于加载重定位后的依赖库，这样所有插件都能访问到
         ClassLoader bukkitClassLoader = Bukkit.class.getClassLoader();
+
         URLClassLoader urlClassLoader = findURLClassLoader(bukkitClassLoader);
         if (urlClassLoader != null) {
-            this.libraryClassLoaderAccess = URLClassLoaderAccess.create(urlClassLoader);
-        } else {
-            throw new UnsupportedOperationException("Unsupported classloader " + bukkitClassLoader.getClass());
+            URLClassLoaderAccess access = URLClassLoaderAccess.create(urlClassLoader);
+            this.delegate = file -> {
+                try {
+                    access.addURL(file.toUri().toURL());
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            return;
         }
+
+        JdkBuiltinClassPathAppender jdkBuiltinAppender =
+                JdkBuiltinClassPathAppender.createIfSupported(bukkitClassLoader);
+
+        if (jdkBuiltinAppender != null) {
+            this.delegate = jdkBuiltinAppender;
+            return;
+        }
+
+        throw new UnsupportedOperationException(
+                "Unsupported classloader " + bukkitClassLoader.getClass()
+                        + ". Expected URLClassLoader or JDK BuiltinClassLoader/AppClassLoader."
+        );
     }
 
     private static URLClassLoader findURLClassLoader(ClassLoader classLoader) {
-        if (classLoader instanceof URLClassLoader urlClassLoader) return urlClassLoader;
+        if (classLoader instanceof URLClassLoader urlClassLoader) {
+            return urlClassLoader;
+        }
+
         ClassLoader parent = classLoader.getParent();
         return parent == null ? null : findURLClassLoader(parent);
     }
 
     @Override
     public void addJarToClasspath(Path file) {
-        try {
-            this.libraryClassLoaderAccess.addURL(file.toUri().toURL());
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
+        this.delegate.addJarToClasspath(file);
     }
 }

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/classpath/JdkBuiltinClassPathAppender.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/classpath/JdkBuiltinClassPathAppender.java
@@ -1,0 +1,76 @@
+package net.momirealms.craftengine.core.plugin.classpath;
+
+import net.momirealms.craftengine.core.util.ReflectionUtils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+
+public final class JdkBuiltinClassPathAppender implements ClassPathAppender {
+    private final MethodHandle appendPath;
+
+    private JdkBuiltinClassPathAppender(ClassLoader classLoader, MethodHandle appendPath) {
+        this.appendPath = appendPath.bindTo(classLoader);
+    }
+
+    public static JdkBuiltinClassPathAppender createIfSupported(ClassLoader classLoader) {
+        if (classLoader == null) {
+            return null;
+        }
+
+        Method appendMethod = findAppendMethod(classLoader.getClass());
+        if (appendMethod == null) {
+            return null;
+        }
+
+        try {
+            return new JdkBuiltinClassPathAppender(
+                    classLoader,
+                    ReflectionUtils.LOOKUP.unreflect(appendMethod)
+            );
+        } catch (IllegalAccessException e) {
+            throw new UnsupportedOperationException(
+                    "Unable to access JDK BuiltinClassLoader classpath appender: "
+                            + classLoader.getClass().getName(),
+                    e
+            );
+        }
+    }
+
+    private static Method findAppendMethod(Class<?> clazz) {
+        Class<?> current = clazz;
+
+        while (current != null) {
+            try {
+                return current.getDeclaredMethod("appendToClassPathForInstrumentation", String.class);
+            } catch (NoSuchMethodException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        current = clazz;
+        while (current != null) {
+            if ("jdk.internal.loader.BuiltinClassLoader".equals(current.getName())) {
+                try {
+                    return current.getDeclaredMethod("appendClassPath", String.class);
+                } catch (NoSuchMethodException ignored) {
+                    return null;
+                }
+            }
+            current = current.getSuperclass();
+        }
+
+        return null;
+    }
+
+    @Override
+    public void addJarToClasspath(Path file) {
+        try {
+            this.appendPath.invoke(file.toAbsolutePath().normalize().toString());
+        } catch (Throwable e) {
+            throw new UnsupportedOperationException(
+                    "Unable to append jar to JDK BuiltinClassLoader: " + file.toAbsolutePath(),
+                    e
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fix plugin unable to load in development environment, Bukkit class was loaded through BuiltinClassLoader in dev server.


```txt
java.lang.UnsupportedOperationException: Unsupported classloader class jdk.internal.loader.ClassLoaders$AppClassLoader
	at craft-engine-paper-plugin-26.5-SNAPSHOT.jar//net.momirealms.craftengine.bukkit.plugin.classpath.BukkitClassPathAppender.<init>(BukkitClassPathAppender.java:21) ~[?:?]
	at craft-engine-paper-plugin-26.5-SNAPSHOT.jar//net.momirealms.craftengine.bukkit.plugin.PaperCraftEngineBootstrap.bootstrap(PaperCraftEngineBootstrap.java:45) ~[?:?]
	at io.papermc.paper.plugin.storage.BootstrapProviderStorage$1.load(BootstrapProviderStorage.java:36) ~[main/:?]
	at io.papermc.paper.plugin.storage.BootstrapProviderStorage$1.load(BootstrapProviderStorage.java:24) ~[main/:?]
	at io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:117) ~[main/:?]
	at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[main/:?]
	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:39) ~[main/:?]
	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enterBootstrappers(LaunchEntryPointHandler.java:29) ~[main/:?]
	at net.minecraft.server.Bootstrap.bootStrap(Bootstrap.java:46) ~[main/:?]
	at net.minecraft.server.Main.main(Main.java:118) ~[main/:?]
	at io.papermc.paper.PaperBootstrap.boot(PaperBootstrap.java:21) ~[main/:?]
	at org.bukkit.craftbukkit.Main.main(Main.java:212) ~[main/:?]
```