### PR TITLE
Add IsExplosionCondition.java to CommonConditions

### DIFF
--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/CommonConditions.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/CommonConditions.java
@@ -42,6 +42,7 @@ public final class CommonConditions {
     public static final CommonConditionType<OpenWaterCondition<Context>> OPEN_WATER = register(Key.ce("open_water"), OpenWaterCondition.factory());
     public static final CommonConditionType<BiomeCondition<Context>> IN_BIOME = register(Key.ce("biome"), BiomeCondition.factory());
     public static final CommonConditionType<WorldCondition<Context>> IN_WORLD = register(Key.ce("world"), WorldCondition.factory());
+    public static final CommonConditionType<IsExplosionCondition<Context>> IS_EXPLOSION = register(Key.ce("is_explosion"), IsExplosionCondition.factory());
 
     private CommonConditions() {}
 

--- a/core/src/main/java/net/momirealms/craftengine/core/plugin/context/condition/IsExplosionCondition.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/plugin/context/condition/IsExplosionCondition.java
@@ -1,0 +1,29 @@
+package net.momirealms.craftengine.core.plugin.context.condition;
+
+import net.momirealms.craftengine.core.plugin.config.ConfigSection;
+import net.momirealms.craftengine.core.plugin.context.Condition;
+import net.momirealms.craftengine.core.plugin.context.Context;
+import net.momirealms.craftengine.core.plugin.context.parameter.DirectContextParameters;
+
+public final class IsExplosionCondition<CTX extends Context> implements Condition<CTX> {
+    public static final IsExplosionCondition<Context> INSTANCE = new IsExplosionCondition<>();
+
+    private IsExplosionCondition() {}
+
+    @Override
+    public boolean test(CTX ctx) {
+        return ctx.getOptionalParameter(DirectContextParameters.EXPLOSION_RADIUS).isPresent();
+    }
+
+    public static <CTX extends Context> ConditionFactory<CTX, IsExplosionCondition<CTX>> factory() {
+        return new Factory<>();
+    }
+
+    private static class Factory<CTX extends Context> implements ConditionFactory<CTX, IsExplosionCondition<CTX>> {
+        @SuppressWarnings("unchecked")
+        @Override
+        public IsExplosionCondition<CTX> create(ConfigSection section) {
+            return (IsExplosionCondition<CTX>) INSTANCE;
+        }
+    }
+}


### PR DESCRIPTION
A reliable check for whether a block was destroyed by an explosion.
Lets loot tables branch on type: is_explosion / !is_explosion.