### PR TITLE
Pack injection api

### DIFF
--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/api/CraftEngineItems.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/api/CraftEngineItems.java
@@ -4,6 +4,7 @@ import net.momirealms.craftengine.bukkit.item.BukkitItemDefinition;
 import net.momirealms.craftengine.bukkit.item.BukkitItemManager;
 import net.momirealms.craftengine.bukkit.util.ItemStackUtils;
 import net.momirealms.craftengine.core.item.ItemDefinition;
+import net.momirealms.craftengine.core.item.processor.ObfuscatedItemModelProcessor;
 import net.momirealms.craftengine.core.util.Key;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -86,5 +87,19 @@ public final class CraftEngineItems {
     public static Key getCustomItemId(@NotNull ItemStack itemStack) {
         if (ItemStackUtils.isEmpty(itemStack)) return null;
         return BukkitItemManager.instance().wrap(itemStack).customId().orElse(null);
+    }
+
+    /**
+     * Gets the item model key the client will actually see for a given key, accounting for resource
+     * pack item model obfuscation.
+     * <p>
+     *
+     * @param itemModel the item model key as registered
+     * @return the obfuscated key, or {@code itemModel} unchanged when obfuscation is off or the key
+     *         was never obfuscated
+     */
+    @NotNull
+    public static Key clientItemModel(@NotNull Key itemModel) {
+        return ObfuscatedItemModelProcessor.getMappings().getOrDefault(itemModel, itemModel);
     }
 }

--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/api/event/AsyncResourcePackInjectEvent.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/api/event/AsyncResourcePackInjectEvent.java
@@ -1,0 +1,124 @@
+package net.momirealms.craftengine.bukkit.api.event;
+
+import net.momirealms.craftengine.core.item.ItemManager;
+import net.momirealms.craftengine.core.pack.PackInjection;
+import net.momirealms.craftengine.core.pack.model.definition.ModernItemModel;
+import net.momirealms.craftengine.core.pack.model.generation.ModelGeneration;
+import net.momirealms.craftengine.core.util.Key;
+import net.momirealms.craftengine.core.util.MinecraftVersion;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is triggered at the start of resource pack generation, after CraftEngine has finished
+ * parsing its own configuration but before any pack content has been written.
+ * <p>
+ * Use it to contribute item definitions, models and textures to the pack CraftEngine is about to
+ * build. Content registered here is written after everything CraftEngine generates itself, so a
+ * collision with a CraftEngine-owned file is skipped with a warning rather than overwriting it.
+ * </p>
+ * <p>
+ * Important: you must register your content every time this event is called. Nothing is remembered
+ * between pack generations.
+ * </p>
+ *
+ * @see AsyncResourcePackCacheEvent for merging a complete external resource pack instead
+ */
+public final class AsyncResourcePackInjectEvent extends Event {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+    private final PackInjection injection;
+
+    @ApiStatus.Internal
+    public AsyncResourcePackInjectEvent(@NotNull PackInjection injection) {
+        super(true);
+        this.injection = injection;
+    }
+
+    @NotNull
+    public PackInjection injection() {
+        return this.injection;
+    }
+
+    /**
+     * Registers an item definition, written to {@code assets/<namespace>/items/<path>.json}.
+     * The key is left exactly as given.
+     *
+     * @param itemModel the item model key
+     * @param model     the definition to write
+     */
+    public void registerItemDefinition(@NotNull Key itemModel, @NotNull ModernItemModel model) {
+        this.injection.registerItemDefinition(itemModel, model);
+    }
+
+    /**
+     * Registers an item definition, written to {@code assets/<namespace>/items/<path>.json}.
+     *
+     * @param itemModel        the item model key
+     * @param model            the definition to write
+     * @param allowObfuscation whether this key may be renamed by item model obfuscation. Only pass
+     *                         {@code true} if you resolve the key through
+     *                         {@code CraftEngineItems#clientItemModel(Key)} when sending the item.
+     */
+    public void registerItemDefinition(@NotNull Key itemModel, @NotNull ModernItemModel model, boolean allowObfuscation) {
+        this.injection.registerItemDefinition(itemModel, model, allowObfuscation);
+    }
+
+    /**
+     * Registers a model, written to {@code assets/<namespace>/models/<path>.json}.
+     *
+     * @param path  the model key
+     * @param model the model to write
+     */
+    public void registerModel(@NotNull Key path, @NotNull ModelGeneration model) {
+        this.injection.registerModel(path, model);
+    }
+
+    /**
+     * Registers a texture, written to {@code assets/<namespace>/textures/<path>.png}.
+     * <p>
+     * The path decides atlas coverage: a key under {@code item/} or {@code block/} is picked up by the
+     * vanilla atlas directory sources in every namespace, anywhere else needs its own atlas entry.
+     *
+     * @param path the texture key, without the {@code .png} extension
+     * @param png  the PNG bytes
+     */
+    public void registerTexture(@NotNull Key path, byte @NotNull[] png) {
+        this.injection.registerTexture(path, png);
+    }
+
+    /**
+     * @return the item manager, for resolving the models that existing items render with
+     */
+    @NotNull
+    public ItemManager itemManager() {
+        return this.injection.itemManager();
+    }
+
+    /**
+     * @return the lowest pack format version this pack targets
+     */
+    @NotNull
+    public MinecraftVersion packMinVersion() {
+        return this.injection.packMinVersion();
+    }
+
+    /**
+     * @return the highest pack format version this pack targets
+     */
+    @NotNull
+    public MinecraftVersion packMaxVersion() {
+        return this.injection.packMaxVersion();
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+}

--- a/bukkit/src/main/java/net/momirealms/craftengine/bukkit/pack/BukkitPackManager.java
+++ b/bukkit/src/main/java/net/momirealms/craftengine/bukkit/pack/BukkitPackManager.java
@@ -3,12 +3,16 @@ package net.momirealms.craftengine.bukkit.pack;
 import net.momirealms.craftengine.bukkit.api.BukkitAdaptor;
 import net.momirealms.craftengine.bukkit.api.event.AsyncResourcePackCacheEvent;
 import net.momirealms.craftengine.bukkit.api.event.AsyncResourcePackGenerateEvent;
+import net.momirealms.craftengine.bukkit.api.event.AsyncResourcePackInjectEvent;
 import net.momirealms.craftengine.bukkit.plugin.BukkitCraftEngine;
 import net.momirealms.craftengine.bukkit.plugin.command.feature.ReloadCommand;
 import net.momirealms.craftengine.bukkit.util.EventUtils;
 import net.momirealms.craftengine.bukkit.util.ResourcePackUtils;
 import net.momirealms.craftengine.core.entity.player.Player;
 import net.momirealms.craftengine.core.pack.AbstractPackManager;
+import net.momirealms.craftengine.core.pack.PackCacheData;
+import net.momirealms.craftengine.core.pack.PackEventDispatcher;
+import net.momirealms.craftengine.core.pack.PackInjection;
 import net.momirealms.craftengine.core.pack.host.ResourcePackDownloadData;
 import net.momirealms.craftengine.core.pack.obfuscation.ObfA;
 import net.momirealms.craftengine.core.plugin.config.Config;
@@ -21,8 +25,10 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.jetbrains.annotations.NotNull;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -31,17 +37,22 @@ public final class BukkitPackManager extends AbstractPackManager implements List
     private final BukkitCraftEngine plugin;
 
     public BukkitPackManager(BukkitCraftEngine plugin) {
-        super(
-                plugin,
-                (cd) -> {
-                    AsyncResourcePackCacheEvent cacheEvent = new AsyncResourcePackCacheEvent(cd);
-                    EventUtils.fireAndForget(cacheEvent);
-                },
-                (rf, zp) -> {
-                    AsyncResourcePackGenerateEvent endEvent = new AsyncResourcePackGenerateEvent(rf, zp);
-                    EventUtils.fireAndForget(endEvent);
-                }
-        );
+        super(plugin, new PackEventDispatcher() {
+            @Override
+            public void onCache(@NotNull PackCacheData cacheData) {
+                EventUtils.fireAndForget(new AsyncResourcePackCacheEvent(cacheData));
+            }
+
+            @Override
+            public void onInject(@NotNull PackInjection injection) {
+                EventUtils.fireAndForget(new AsyncResourcePackInjectEvent(injection));
+            }
+
+            @Override
+            public void onGenerate(@NotNull Path packFolder, @NotNull Path zipFile) {
+                EventUtils.fireAndForget(new AsyncResourcePackGenerateEvent(packFolder, zipFile));
+            }
+        });
         this.plugin = plugin;
     }
 

--- a/core/src/main/java/net/momirealms/craftengine/core/item/AbstractItemManager.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/item/AbstractItemManager.java
@@ -212,6 +212,25 @@ public abstract class AbstractItemManager extends AbstractModelGenerator impleme
     }
 
     @Override
+    public Optional<ModernItemModel> getModernItemModel(@NotNull Key itemModel) {
+        ModernItemModel model = this.modernItemModels1_21_4.get(itemModel);
+        if (model == null) model = AbstractPackManager.PRESET_ITEMS.get(itemModel);
+        return Optional.ofNullable(model);
+    }
+
+    @Override
+    public Optional<ModernItemModel> getModernItemModel(@NotNull Key itemModel, int customModelData) {
+        if (customModelData != 0) {
+            TreeMap<Integer, ModernItemModel> overrides = this.modernOverrides.get(itemModel);
+            if (overrides != null) {
+                ModernItemModel model = overrides.get(customModelData);
+                if (model != null) return Optional.of(model);
+            }
+        }
+        return getModernItemModel(itemModel);
+    }
+
+    @Override
     public Map<Key, ModernItemModel> modernItemModels1_21_4() {
         return Collections.unmodifiableMap(this.modernItemModels1_21_4);
     }

--- a/core/src/main/java/net/momirealms/craftengine/core/item/ItemManager.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/item/ItemManager.java
@@ -107,6 +107,10 @@ public interface ItemManager extends Manageable, ModelGenerator {
 
     Set<Key> getVanillaItemTags(Key item);
 
+    Optional<ModernItemModel> getModernItemModel(@NotNull Key itemModel);
+
+    Optional<ModernItemModel> getModernItemModel(@NotNull Key itemModel, int customModelData);
+
     @ApiStatus.Internal
     Map<Key, TreeSet<LegacyOverridesModel>> legacyItemOverrides();
 

--- a/core/src/main/java/net/momirealms/craftengine/core/pack/AbstractPackManager.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/pack/AbstractPackManager.java
@@ -133,8 +133,7 @@ public abstract class AbstractPackManager implements PackManager {
     }
 
     private final CraftEngine plugin;
-    private final Consumer<PackCacheData> cacheEventDispatcher;
-    private final BiConsumer<Path, Path> generationEventDispatcher;
+    private final PackEventDispatcher eventDispatcher;
     private final Map<String, Pack> loadedPacks = new LinkedHashMap<>();
     private final Map<String, ConfigParser> sectionParsers = new HashMap<>();
     public final JsonObject vanillaBlockAtlas;
@@ -147,10 +146,9 @@ public abstract class AbstractPackManager implements PackManager {
     private final ConfigFactoryParser bundleParser = new ConfigFactoryParser();
     private final AtlasConfigParser atlasConfigParser = new AtlasConfigParser();
 
-    public AbstractPackManager(CraftEngine plugin, Consumer<PackCacheData> cacheEventDispatcher, BiConsumer<Path, Path> generationEventDispatcher) {
+    public AbstractPackManager(CraftEngine plugin, PackEventDispatcher eventDispatcher) {
         this.plugin = plugin;
-        this.cacheEventDispatcher = cacheEventDispatcher;
-        this.generationEventDispatcher = generationEventDispatcher;
+        this.eventDispatcher = eventDispatcher;
         this.zipGenerator = (p1, p2) -> {
             try {
                 ZipUtils.compress(p1, p2);
@@ -366,7 +364,7 @@ public abstract class AbstractPackManager implements PackManager {
     public void initCachedAssets() {
         try {
             PackCacheData cacheData = new PackCacheData(this.plugin);
-            this.cacheEventDispatcher.accept(cacheData);
+            this.eventDispatcher.onCache(cacheData);
             this.updateCachedAssets(cacheData, null);
         } catch (Exception e) {
             this.plugin.logger().warn("Failed to update cached assets", e);
@@ -642,7 +640,7 @@ public abstract class AbstractPackManager implements PackManager {
                     return;
                 }
                 this.plugin.logger().info(TranslationManager.instance().plainTranslation("resource.config_loaded",
-                       parser.loadingStage().name(), String.format("%.2f", ((t2 - t1) / 1_000_000.0)), String.valueOf(count)));
+                        parser.loadingStage().name(), String.format("%.2f", ((t2 - t1) / 1_000_000.0)), String.valueOf(count)));
             });
         }
         pyramid.execute().join();
@@ -693,7 +691,10 @@ public abstract class AbstractPackManager implements PackManager {
 
         // Create cache data
         PackCacheData cacheData = new PackCacheData(this.plugin);
-        this.cacheEventDispatcher.accept(cacheData);
+        this.eventDispatcher.onCache(cacheData);
+
+        PackInjection injection = new PackInjection(this.plugin.itemManager(), Config.packMinVersion(), Config.packMaxVersion());
+        this.eventDispatcher.onInject(injection);
 
         // get the target location
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.forCurrentPlatform())) {
@@ -725,6 +726,7 @@ public abstract class AbstractPackManager implements PackManager {
             this.generateModernItemModels1_21_4(generatedPackPath, revisions::add);
             this.generateLegacyItemOverrides(generatedPackPath);
             this.generateModernItemOverrides(generatedPackPath, revisions::add);
+            this.writeInjectedAssets(generatedPackPath, injection, revisions::add);
             this.generateOverrideSounds(generatedPackPath);
             this.generateCustomSounds(generatedPackPath);
             this.generateClientLang(generatedPackPath);
@@ -819,7 +821,7 @@ public abstract class AbstractPackManager implements PackManager {
                 this.plugin.logger().error("Error creating resource pack", e);
             }
             this.plugin.logger().info(TranslationManager.instance().plainTranslation("resource_pack.compression_finished", String.valueOf(timestamp.deltaMillis())));
-            this.generationEventDispatcher.accept(generatedPackPath, finalPath);
+            this.eventDispatcher.onGenerate(generatedPackPath, finalPath);
             if (Config.autoUpload() && resourcePackHost().canUpload()) {
                 uploadResourcePack();
             }
@@ -3067,10 +3069,93 @@ public abstract class AbstractPackManager implements PackManager {
         for (Map.Entry<String, JsonElement> pair : sorted.entrySet()) {
             sortedJson.add(pair.getKey(), pair.getValue());
         }
-        writeJsonSafely(sortedJson, soundPath);
+        this.writeJsonSafely(sortedJson, soundPath);
     }
 
     // 生成 json 模型文件
+    private void writeInjectedAssets(Path generatedPackPath, PackInjection injection, Consumer<Revision> callback) {
+        if (injection.isEmpty()) return;
+
+        for (Map.Entry<Key, byte[]> entry : injection.textures().entrySet()) {
+            this.writeInjectedTexture(generatedPackPath, entry.getKey(), entry.getValue());
+        }
+
+        for (Map.Entry<Key, ModelGeneration> entry : injection.models().entrySet()) {
+            Key key = entry.getKey();
+            Path modelPath = generatedPackPath
+                    .resolve("assets")
+                    .resolve(key.namespace())
+                    .resolve("models")
+                    .resolve(key.value() + ".json");
+            if (Files.exists(modelPath)) {
+                this.plugin.logger().warn(TranslationManager.instance().plainTranslation("resource_pack.model_generation.conflict", modelPath.toAbsolutePath().toString()));
+                continue;
+            }
+            ModelGeneration model = entry.getValue();
+            this.writeJsonSafely(model.get(), modelPath);
+            model.rawTextures().forEach((path, png) -> this.writeInjectedTexture(generatedPackPath, path, png));
+        }
+
+        if (Config.packMaxVersion().isBelow(MinecraftVersion.V1_21_4)) {
+            if (!injection.itemDefinitions().isEmpty()) {
+                this.plugin.logger().warn("Skipped " + injection.itemDefinitions().size() + " injected item definitions because the max pack version is below 1.21.4");
+            }
+            return;
+        }
+
+        boolean obfuscateItemModel = Config.obfuscateItemModel();
+        for (Map.Entry<Key, ModernItemModel> entry : injection.itemDefinitions().entrySet()) {
+            Key key = entry.getKey();
+            Path itemPath = generatedPackPath
+                    .resolve("assets")
+                    .resolve(key.namespace())
+                    .resolve("items")
+                    .resolve(key.value() + ".json");
+            if (Files.exists(itemPath)) {
+                this.plugin.logger().warn(TranslationManager.instance().plainTranslation("resource_pack.item_model.conflict", key.asString(), itemPath.toAbsolutePath().toString()));
+                continue;
+            }
+
+            ModernItemModel modernItemModel = entry.getValue();
+            this.writeJsonSafely(modernItemModel.toJson(Config.packMinVersion()), itemPath);
+
+            if (obfuscateItemModel && injection.canObfuscate(key)) {
+                ObfuscatedItemModelProcessor.CAN_OBF.add(key);
+            }
+
+            for (Revision revision : modernItemModel.revisions()) {
+                if (revision.matches(Config.packMinVersion(), Config.packMaxVersion())) {
+                    Path overlayItemPath = generatedPackPath
+                            .resolve(Config.createOverlayFolderName(revision.versionString()))
+                            .resolve("assets")
+                            .resolve(key.namespace())
+                            .resolve("items")
+                            .resolve(key.value() + ".json");
+                    this.writeJsonSafely(modernItemModel.toJson(revision.minVersion(), revision.maxVersion()), overlayItemPath);
+                    callback.accept(revision);
+                }
+            }
+        }
+    }
+
+    private void writeInjectedTexture(Path generatedPackPath, Key key, byte[] png) {
+        Path texturePath = generatedPackPath
+                .resolve("assets")
+                .resolve(key.namespace())
+                .resolve("textures")
+                .resolve(key.value() + ".png");
+        if (Files.exists(texturePath)) {
+            this.plugin.logger().warn(TranslationManager.instance().plainTranslation("resource_pack.texture_generation.conflict", texturePath.toAbsolutePath().toString()));
+            return;
+        }
+        try {
+            Files.createDirectories(texturePath.getParent());
+            Files.write(texturePath, png);
+        } catch (IOException e) {
+            this.plugin.logger().warn("Failed to generate injected texture " + texturePath.toAbsolutePath(), e);
+        }
+    }
+
     private void generateModels(Path generatedPackPath, ModelGenerator generator) {
         for (Map.Entry<Key, ModelGeneration> entry : generator.modelsToGenerate().entrySet()) {
             Path modelPath = generatedPackPath

--- a/core/src/main/java/net/momirealms/craftengine/core/pack/PackEventDispatcher.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/pack/PackEventDispatcher.java
@@ -1,0 +1,16 @@
+package net.momirealms.craftengine.core.pack;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+
+@ApiStatus.Internal
+public interface PackEventDispatcher {
+
+    void onCache(@NotNull PackCacheData cacheData);
+
+    void onInject(@NotNull PackInjection injection);
+
+    void onGenerate(@NotNull Path packFolder, @NotNull Path zipFile);
+}

--- a/core/src/main/java/net/momirealms/craftengine/core/pack/PackInjection.java
+++ b/core/src/main/java/net/momirealms/craftengine/core/pack/PackInjection.java
@@ -1,0 +1,154 @@
+package net.momirealms.craftengine.core.pack;
+
+import net.momirealms.craftengine.core.item.ItemManager;
+import net.momirealms.craftengine.core.pack.model.definition.ModernItemModel;
+import net.momirealms.craftengine.core.pack.model.generation.ModelGeneration;
+import net.momirealms.craftengine.core.util.Key;
+import net.momirealms.craftengine.core.util.MinecraftVersion;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Collects item definitions, models and textures contributed by other plugins for the resource pack
+ * that is about to be generated.
+ * <p>
+ * Content is buffered here rather than written straight into the pack so that everything CraftEngine
+ * itself generates takes precedence, and so contributors never get a reference to CraftEngine's own
+ * mutable registries.
+ * <p>
+ * Insertion order is preserved to keep pack generation reproducible. This type is not thread safe;
+ * it is populated by a single synchronous dispatch and consumed immediately afterwards.
+ */
+public final class PackInjection {
+    private final ItemManager itemManager;
+    private final MinecraftVersion packMinVersion;
+    private final MinecraftVersion packMaxVersion;
+    private final Map<Key, ModernItemModel> itemDefinitions = new LinkedHashMap<>();
+    private final Set<Key> obfuscatableItemDefinitions = new LinkedHashSet<>();
+    private final Map<Key, ModelGeneration> models = new LinkedHashMap<>();
+    private final Map<Key, byte[]> textures = new LinkedHashMap<>();
+
+    @ApiStatus.Internal
+    public PackInjection(@NotNull ItemManager itemManager, @NotNull MinecraftVersion packMinVersion, @NotNull MinecraftVersion packMaxVersion) {
+        this.itemManager = itemManager;
+        this.packMinVersion = packMinVersion;
+        this.packMaxVersion = packMaxVersion;
+    }
+
+    /**
+     * Registers an item definition, written to {@code assets/<namespace>/items/<path>.json}.
+     * <p>
+     * Equivalent to {@link #registerItemDefinition(Key, ModernItemModel, boolean)} with obfuscation
+     * disabled, which is the safe default: the key stays exactly as given, so a plugin that sets the
+     * {@code minecraft:item_model} component itself can rely on it.
+     *
+     * @param itemModel the item model key
+     * @param model     the definition to write
+     */
+    public void registerItemDefinition(@NotNull Key itemModel, @NotNull ModernItemModel model) {
+        this.registerItemDefinition(itemModel, model, false);
+    }
+
+    /**
+     * Registers an item definition, written to {@code assets/<namespace>/items/<path>.json}.
+     * <p>
+     * Pass {@code allowObfuscation} only if the caller resolves the key through
+     * {@code CraftEngineItems#clientItemModel(Key)} every time it sends the item. Item model
+     * obfuscation renames the definition file and remaps the key, and the mapping is not known until
+     * after generation finishes, so a cached key will be stale.
+     *
+     * @param itemModel        the item model key
+     * @param model            the definition to write
+     * @param allowObfuscation whether this key may be renamed by item model obfuscation
+     */
+    public void registerItemDefinition(@NotNull Key itemModel, @NotNull ModernItemModel model, boolean allowObfuscation) {
+        Objects.requireNonNull(itemModel, "itemModel");
+        this.itemDefinitions.put(itemModel, Objects.requireNonNull(model, "model"));
+        if (allowObfuscation) {
+            this.obfuscatableItemDefinitions.add(itemModel);
+        } else {
+            this.obfuscatableItemDefinitions.remove(itemModel);
+        }
+    }
+
+    /**
+     * Registers a model, written to {@code assets/<namespace>/models/<path>.json}. Any raw textures
+     * carried by the {@link ModelGeneration} are written too.
+     *
+     * @param path  the model key
+     * @param model the model to write
+     */
+    public void registerModel(@NotNull Key path, @NotNull ModelGeneration model) {
+        this.models.put(Objects.requireNonNull(path, "path"), Objects.requireNonNull(model, "model"));
+    }
+
+    /**
+     * Registers a texture, written to {@code assets/<namespace>/textures/<path>.png}.
+     * <p>
+     * Note that the path decides atlas coverage. A key under {@code item/} or {@code block/} is picked
+     * up by the vanilla atlas directory sources in every namespace; anywhere else needs its own atlas
+     * entry, or the sprite is never stitched.
+     *
+     * @param path the texture key, without the {@code .png} extension
+     * @param png  the PNG bytes
+     */
+    public void registerTexture(@NotNull Key path, byte @NotNull [] png) {
+        this.textures.put(Objects.requireNonNull(path, "path"), Objects.requireNonNull(png, "png"));
+    }
+
+    /**
+     * @return the item manager, for resolving the models that existing items render with
+     */
+    @NotNull
+    public ItemManager itemManager() {
+        return this.itemManager;
+    }
+
+    /**
+     * @return the lowest pack format version this pack targets
+     */
+    @NotNull
+    public MinecraftVersion packMinVersion() {
+        return this.packMinVersion;
+    }
+
+    /**
+     * @return the highest pack format version this pack targets
+     */
+    @NotNull
+    public MinecraftVersion packMaxVersion() {
+        return this.packMaxVersion;
+    }
+
+    @ApiStatus.Internal
+    public Map<Key, ModernItemModel> itemDefinitions() {
+        return Collections.unmodifiableMap(this.itemDefinitions);
+    }
+
+    @ApiStatus.Internal
+    public boolean canObfuscate(@NotNull Key itemModel) {
+        return this.obfuscatableItemDefinitions.contains(itemModel);
+    }
+
+    @ApiStatus.Internal
+    public Map<Key, ModelGeneration> models() {
+        return Collections.unmodifiableMap(this.models);
+    }
+
+    @ApiStatus.Internal
+    public Map<Key, byte[]> textures() {
+        return Collections.unmodifiableMap(this.textures);
+    }
+
+    @ApiStatus.Internal
+    public boolean isEmpty() {
+        return this.itemDefinitions.isEmpty() && this.models.isEmpty() && this.textures.isEmpty();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new event-driven mechanism for injecting custom assets into the resource pack generation process, along with public APIs for registering custom item models, textures, and definitions. It also refactors the pack event dispatching system to support the new injection event and provides utility methods for resolving obfuscated item model keys. These changes make it easier for plugins and extensions to contribute custom content to resource packs in a controlled and safe manner.

**Resource Pack Injection and Event System:**

* Added a new event, `AsyncResourcePackInjectEvent`, which is fired at the start of resource pack generation to allow plugins to register custom item definitions, models, and textures. This event provides methods to safely inject assets and handle obfuscation concerns.
* Introduced the `PackEventDispatcher` interface and refactored `AbstractPackManager` and `BukkitPackManager` to use it, enabling the new injection event alongside existing cache and generation events. [[1]](diffhunk://#diff-3695f63791c484f029c494aeed8c734a8847ec8241505fda9fbd71607d9a13adR1-R16) [[2]](diffhunk://#diff-1956d240c9da68f52bfb0c72681ec1d251f8d1cae147279e9bb127e5745d4f2fL136-R136) [[3]](diffhunk://#diff-1956d240c9da68f52bfb0c72681ec1d251f8d1cae147279e9bb127e5745d4f2fL150-R151) [[4]](diffhunk://#diff-37bdc84aca1fd9c5d4fce58eb37165f1359712370c7c19bdadab9d701257df8cR6-R15) [[5]](diffhunk://#diff-37bdc84aca1fd9c5d4fce58eb37165f1359712370c7c19bdadab9d701257df8cR28-R31) [[6]](diffhunk://#diff-37bdc84aca1fd9c5d4fce58eb37165f1359712370c7c19bdadab9d701257df8cL34-R55)

**Resource Pack Generation Logic:**

* Implemented logic in `AbstractPackManager` to handle injected assets, writing custom models, textures, and item definitions, with conflict detection and warnings for overwrites. Obfuscation flags are respected, and assets are written to the correct locations. [[1]](diffhunk://#diff-1956d240c9da68f52bfb0c72681ec1d251f8d1cae147279e9bb127e5745d4f2fL3070-R3158) [[2]](diffhunk://#diff-1956d240c9da68f52bfb0c72681ec1d251f8d1cae147279e9bb127e5745d4f2fR729)

**API Enhancements:**

* Added new public API methods in `CraftEngineItems` for resolving the client-visible (potentially obfuscated) item model key, and in `ItemManager`/`AbstractItemManager` for retrieving modern item models by key and custom model data. [[1]](diffhunk://#diff-0d179f7b18176a904c7f2ae5014c26eec6fbd4d2113a7b45911e204fa1d72928R7) [[2]](diffhunk://#diff-0d179f7b18176a904c7f2ae5014c26eec6fbd4d2113a7b45911e204fa1d72928R91-R104) [[3]](diffhunk://#diff-fa851caa71a9b77e03b860255a0cbc0220bf68837c2d2b6ff6320c972cc52d35R110-R113) [[4]](diffhunk://#diff-48797c34f94e3821fe58e2241f78050ced19ac43a7d7aa1483cd943f25cb4fcdR214-R232)

**Event Dispatching Refactor:**

* Replaced the previous event dispatching approach in `AbstractPackManager` and `BukkitPackManager` with a unified, extensible `PackEventDispatcher` interface, supporting cache, inject, and generate events. [[1]](diffhunk://#diff-1956d240c9da68f52bfb0c72681ec1d251f8d1cae147279e9bb127e5745d4f2fL369-R367) [[2]](diffhunk://#diff-1956d240c9da68f52bfb0c72681ec1d251f8d1cae147279e9bb127e5745d4f2fL696-R697) [[3]](diffhunk://#diff-1956d240c9da68f52bfb0c72681ec1d251f8d1cae147279e9bb127e5745d4f2fL822-R824) [[4]](diffhunk://#diff-37bdc84aca1fd9c5d4fce58eb37165f1359712370c7c19bdadab9d701257df8cL34-R55)